### PR TITLE
Add file helper functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,10 @@
 *.recipe
 *.vcxproj.FileListAbsolute.txt
 
+# Resource Files
+*.aps
+*.res
+
 # Logs
 *.log
 *.plg
@@ -33,10 +37,18 @@
 *.DS_STORE
 *.db
 
-# Visual Studio Solution / Project Files
+# Visual Studio 2005 Solution / Project Files
+*.vcproj
+
+# Visual Studio 2010 Solution / Project Files
 .vs
 
 *.sln
 *.vcxproj
 *.vcxproj.filters
 *.vcxproj.user
+
+# Compression Formats
+*.7z
+*.rar
+*.zip

--- a/MDC/MDC.dsp
+++ b/MDC/MDC.dsp
@@ -41,7 +41,7 @@ RSC=rc.exe
 # PROP Intermediate_Dir "Release"
 # PROP Target_Dir ""
 # ADD BASE CPP /nologo /W3 /GX /O2 /D "WIN32" /D "NDEBUG" /D "_MBCS" /D "_LIB" /YX /FD /c
-# ADD CPP /nologo /MD /W3 /GX /O2 /D "NDEBUG" /D "_UNICODE" /D "UNICODE" /D "_LIB" /YX /FD /c
+# ADD CPP /nologo /MD /W3 /GX /O2 /D "NDEBUG" /D "_UNICODE" /D "UNICODE" /D "_LIB" /D "MDC_ACKNOWLEDGE_LIBUNICOWS" /YX /FD /c
 # ADD BASE RSC /l 0x409 /d "NDEBUG"
 # ADD RSC /l 0x409 /d "NDEBUG"
 BSC32=bscmake.exe
@@ -64,7 +64,7 @@ LIB32=link.exe -lib
 # PROP Intermediate_Dir "Debug"
 # PROP Target_Dir ""
 # ADD BASE CPP /nologo /W3 /Gm /GX /ZI /Od /D "WIN32" /D "_DEBUG" /D "_MBCS" /D "_LIB" /YX /FD /GZ /c
-# ADD CPP /nologo /MDd /W3 /Gm /GX /ZI /Od /D "_DEBUG" /D "_UNICODE" /D "UNICODE" /D "_LIB" /YX /FD /GZ /c
+# ADD CPP /nologo /MDd /W3 /Gm /GX /ZI /Od /D "_DEBUG" /D "_UNICODE" /D "UNICODE" /D "_LIB" /D "MDC_ACKNOWLEDGE_LIBUNICOWS" /YX /FD /GZ /c
 # ADD BASE RSC /l 0x409 /d "_DEBUG"
 # ADD RSC /l 0x409 /d "_DEBUG"
 BSC32=bscmake.exe
@@ -168,6 +168,10 @@ SOURCE=.\src\mdc\filesystem\internal\path_windows.c
 SOURCE=.\src\mdc\filesystem\internal\space_info.c
 # End Source File
 # End Group
+# Begin Source File
+
+SOURCE=.\src\mdc\filesystem\current_executable_path.c
+# End Source File
 # End Group
 # Begin Group "malloc_c"
 
@@ -392,6 +396,10 @@ SOURCE=.\include\mdc\filesystem\internal\perms.h
 SOURCE=.\include\mdc\filesystem\internal\space_info.h
 # End Source File
 # End Group
+# Begin Source File
+
+SOURCE=.\include\mdc\filesystem\current_executable_path.h
+# End Source File
 # Begin Source File
 
 SOURCE=.\include\mdc\filesystem\filesystem.h

--- a/MDC/include/mdc/error/exit_on_error.h
+++ b/MDC/include/mdc/error/exit_on_error.h
@@ -34,16 +34,20 @@
 #include "../wchar_t/filew.h"
 
 #if defined(_WIN32) || defined(_WIN64)
-
-#include <windows.h>
-
+  #include <windows.h>
 #endif /* defined(_WIN32) || defined(_WIN64) */
+
+#include "../../../dllexport_define.inc"
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 enum {
   Mdc_Error_kErrorMessageCapacity = 1024
 };
 
-void Mdc_Error_ExitOnGeneralError(
+DLLEXPORT void Mdc_Error_ExitOnGeneralError(
     const wchar_t* caption_text,
     const wchar_t* message_format,
     const wchar_t* file_path_cwstr,
@@ -51,31 +55,31 @@ void Mdc_Error_ExitOnGeneralError(
     ...
 );
 
-void Mdc_Error_ExitOnConstantMappingError(
+DLLEXPORT void Mdc_Error_ExitOnConstantMappingError(
     const wchar_t* file_path_cwstr,
     unsigned int line,
     int value
 );
 
-void Mdc_Error_ExitOnMemoryAllocError(
+DLLEXPORT void Mdc_Error_ExitOnMemoryAllocError(
     const wchar_t* file_path_cwstr,
     unsigned int line
 );
 
-void Mdc_Error_ExitOnMdcFunctionError(
+DLLEXPORT void Mdc_Error_ExitOnMdcFunctionError(
     const wchar_t* file_path_cwstr,
     unsigned int line,
     const wchar_t* function_name
 );
 
-void Mdc_Error_ExitOnStaticInitError(
+DLLEXPORT void Mdc_Error_ExitOnStaticInitError(
     const wchar_t* file_path_cwstr,
     unsigned int line
 );
 
 #if defined(_WIN32) || defined(_WIN64)
 
-void Mdc_Error_ExitOnWindowsFunctionError(
+DLLEXPORT void Mdc_Error_ExitOnWindowsFunctionError(
     const wchar_t* file_path_cwstr,
     unsigned int line,
     const wchar_t* function_name,
@@ -84,4 +88,9 @@ void Mdc_Error_ExitOnWindowsFunctionError(
 
 #endif /* defined(_WIN32) || defined(_WIN64) */
 
+#ifdef __cplusplus
+} /* extern "C" { */
+#endif /* __cplusplus */
+
+#include "../../../dllexport_undefine.inc"
 #endif /* MDC_C_EXIT_ON_ERROR_EXIT_ON_ERROR_H_ */

--- a/MDC/include/mdc/filesystem/current_executable_path.h
+++ b/MDC/include/mdc/filesystem/current_executable_path.h
@@ -1,0 +1,42 @@
+/**
+ * Mir Drualga Common For C
+ * Copyright (C) 2020  Mir Drualga
+ *
+ * This file is part of Mir Drualga Common For C.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any program (or a modified version of that program and its
+ *  libraries), containing parts covered by the terms of an incompatible
+ *  license, the licensors of this Program grant you additional permission
+ *  to convey the resulting work.
+ */
+
+#ifndef MDC_C_FILESYSTEM_CURRENT_EXECUTABLE_PATH_H_
+#define MDC_C_FILESYSTEM_CURRENT_EXECUTABLE_PATH_H_
+
+#include "filesystem.h"
+
+#include "../../../dllexport_define.inc"
+
+DLLEXPORT struct Mdc_Fs_Path* Mdc_Fs_GetCurrentExecutablePath(
+    struct Mdc_Fs_Path* current_executable_path
+);
+
+#include "../../../dllexport_undefine.inc"
+#endif /* MDC_C_FILESYSTEM_CURRENT_EXECUTABLE_PATH_H_ */

--- a/MDC/include/mdc/windows/vs_fixed_file_info.h
+++ b/MDC/include/mdc/windows/vs_fixed_file_info.h
@@ -1,0 +1,77 @@
+/**
+ * Mir Drualga Common For C
+ * Copyright (C) 2020  Mir Drualga
+ *
+ * This file is part of Mir Drualga Common For C.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any program (or a modified version of that program and its
+ *  libraries), containing parts covered by the terms of an incompatible
+ *  license, the licensors of this Program grant you additional permission
+ *  to convey the resulting work.
+ */
+
+#ifndef MDC_C_WINDOWS_VS_FIXED_INFO_H_
+#define MDC_C_WINDOWS_VS_FIXED_INFO_H_
+#if defined(_WIN32) || defined(_WIN64)
+
+#include <windows.h>
+
+#include "../filesystem/filesystem.h"
+#include "../std/stdbool.h"
+
+#include "../../../dllexport_define.inc"
+
+DLLEXPORT VS_FIXEDFILEINFO* Mdc_VS_FIXEDFILEINFO_InitFromPath(
+    VS_FIXEDFILEINFO* fixed_file_info,
+    const struct Mdc_Fs_Path* file_path
+);
+
+DLLEXPORT VS_FIXEDFILEINFO* Mdc_VS_FIXEDFILEINFO_InitCopy(
+    VS_FIXEDFILEINFO* dest,
+    const VS_FIXEDFILEINFO* src
+);
+
+DLLEXPORT VS_FIXEDFILEINFO* Mdc_VS_FIXEDFILEINFO_InitMove(
+    VS_FIXEDFILEINFO* dest,
+    VS_FIXEDFILEINFO* src
+);
+
+DLLEXPORT void Mdc_VS_FIXEDFILEINFO_Deinit(
+    VS_FIXEDFILEINFO* fixed_file_info
+);
+
+DLLEXPORT VS_FIXEDFILEINFO* Mdc_VS_FIXEDFILEINFO_AssignCopy(
+    VS_FIXEDFILEINFO* dest,
+    const VS_FIXEDFILEINFO* src
+);
+
+DLLEXPORT VS_FIXEDFILEINFO* Mdc_VS_FIXEDFILEINFO_AssignMove(
+    VS_FIXEDFILEINFO* dest,
+    VS_FIXEDFILEINFO* src
+);
+
+DLLEXPORT bool Mdc_VS_FIXEDFILEINFO_Equal(
+    const VS_FIXEDFILEINFO* fixed_file_info1,
+    const VS_FIXEDFILEINFO* fixed_file_info2
+);
+
+#include "../../../dllexport_undefine.inc"
+#endif /* defined(_WIN32) || defined(_WIN64) */
+#endif /* MDC_C_WINDOWS_VS_FIXED_INFO_H_ */

--- a/MDC/src/mdc/filesystem/current_executable_path.c
+++ b/MDC/src/mdc/filesystem/current_executable_path.c
@@ -1,0 +1,107 @@
+/**
+ * Mir Drualga Common For C
+ * Copyright (C) 2020  Mir Drualga
+ *
+ * This file is part of Mir Drualga Common For C.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any program (or a modified version of that program and its
+ *  libraries), containing parts covered by the terms of an incompatible
+ *  license, the licensors of this Program grant you additional permission
+ *  to convey the resulting work.
+ */
+
+#include "../../../include/mdc/filesystem/current_executable_path.h"
+
+#include "../../../include/mdc/malloc/malloc.h"
+#include "../../../include/mdc/std/threads.h"
+#include "../../../include/mdc/filesystem/filesystem.h"
+
+#if defined(_WIN32) || defined(_WIN64)
+
+struct Mdc_Fs_Path* Mdc_Fs_GetCurrentExecutablePath(
+    struct Mdc_Fs_Path* current_executable_path
+) {
+  enum {
+    kPathInitialCapacity = 8
+  };
+
+  void* realloc_result;
+
+  struct Mdc_Fs_Path* init_current_executable_path;
+  wchar_t* current_executable_path_cstr;
+  size_t current_executable_path_capacity;
+  size_t current_executable_path_new_capacity;
+  wchar_t current_executable_path_back_value;
+
+  /* Copy the game executable path into the C string. */
+  current_executable_path_cstr = NULL;
+  current_executable_path_new_capacity = kPathInitialCapacity;
+
+  do {
+    current_executable_path_capacity = current_executable_path_new_capacity;
+
+    realloc_result = Mdc_realloc(
+        current_executable_path_cstr,
+        current_executable_path_capacity
+            * sizeof(current_executable_path_cstr[0])
+    );
+
+    if (realloc_result == NULL) {
+      goto free_current_executable_path_cstr;
+    }
+
+    current_executable_path_cstr = realloc_result;
+    current_executable_path_cstr[current_executable_path_capacity - 2]
+        = L'\0';
+
+    GetModuleFileNameW(
+        NULL,
+        current_executable_path_cstr,
+        current_executable_path_capacity
+    );
+
+    current_executable_path_new_capacity *= 2;
+
+    current_executable_path_back_value =
+        current_executable_path_cstr[current_executable_path_capacity - 2];
+  } while (current_executable_path_back_value != L'\0');
+
+  /* The C string now contains the exectuable path. Init the path. */
+  init_current_executable_path = Mdc_Fs_Path_InitFromCWStr(
+      current_executable_path,
+      current_executable_path_cstr
+  );
+
+  if (init_current_executable_path != current_executable_path) {
+    goto free_current_executable_path_cstr;
+  }
+
+  Mdc_free(current_executable_path_cstr);
+
+  return current_executable_path;
+
+free_current_executable_path_cstr:
+  Mdc_free(current_executable_path_cstr);
+
+return_bad:
+  return NULL;
+}
+
+#endif

--- a/MDC/src/mdc/filesystem/internal/filesystem_functions_windows.c
+++ b/MDC/src/mdc/filesystem/internal/filesystem_functions_windows.c
@@ -85,8 +85,6 @@ bool Mdc_Fs_ExistsFromPath(
 struct Mdc_Fs_Path* Mdc_Fs_GetCurrentPath(
     struct Mdc_Fs_Path* current_path
 ) {
-  void* realloc_result;
-
   struct Mdc_Fs_Path* init_current_path;
   DWORD current_path_cap;
   DWORD get_current_directory_result;
@@ -94,19 +92,15 @@ struct Mdc_Fs_Path* Mdc_Fs_GetCurrentPath(
   wchar_t* current_path_cstr;
 
   /* Alloc space for the current path. */
-  current_path_cstr = Mdc_malloc(2);
+  current_path_cap = GetCurrentDirectoryW(0, NULL);
+
+  current_path_cstr = Mdc_malloc(
+      current_path_cap * sizeof(current_path_cstr[0])
+  );
+
   if (current_path_cstr == NULL) {
     goto return_bad;
   }
-
-  current_path_cap = GetCurrentDirectoryW(0, current_path_cstr);
-
-  realloc_result = Mdc_realloc(current_path_cstr, current_path_cap);
-  if (realloc_result == NULL) {
-    goto free_current_path_cstr;
-  }
-
-  current_path_cstr = realloc_result;
 
   /* Get the current path and init the Path object. */
   get_current_directory_result = GetCurrentDirectoryW(

--- a/MDC/src/mdc/malloc/malloc.c
+++ b/MDC/src/mdc/malloc/malloc.c
@@ -67,7 +67,10 @@ void* Mdc_realloc(void* ptr, size_t new_size) {
   result = realloc(ptr, new_size);
 
   if (result != NULL) {
-    free_count += 1;
+    if (ptr != NULL) {
+      free_count += 1;
+    }
+
     malloc_count += 1;
   }
 

--- a/MDC/src/mdc/windows/vs_fixed_file_info.c
+++ b/MDC/src/mdc/windows/vs_fixed_file_info.c
@@ -1,0 +1,168 @@
+/**
+ * Mir Drualga Common For C
+ * Copyright (C) 2020  Mir Drualga
+ *
+ * This file is part of Mir Drualga Common For C.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any program (or a modified version of that program and its
+ *  libraries), containing parts covered by the terms of an incompatible
+ *  license, the licensors of this Program grant you additional permission
+ *  to convey the resulting work.
+ */
+
+#include "../../../include/mdc/windows/vs_fixed_file_info.h"
+
+#if defined(_WIN32) || defined(_WIN64)
+
+#include "../../../include/mdc/malloc/malloc.h"
+
+VS_FIXEDFILEINFO* Mdc_VS_FIXEDFILEINFO_InitFromPath(
+    VS_FIXEDFILEINFO* fixed_file_info,
+    const struct Mdc_Fs_Path* file_path
+) {
+  DWORD ignored;
+
+  const wchar_t* file_path_cstr;
+
+  void* file_version_info;
+  DWORD file_version_info_size;
+
+  BOOL is_get_file_version_info_success;
+  BOOL is_ver_query_value_success;
+
+  VS_FIXEDFILEINFO* temp_fixed_file_info;
+  UINT temp_file_info_size;
+
+  /* Check version size. */
+  file_path_cstr = Mdc_Fs_Path_CStr(file_path);
+
+  file_version_info_size = GetFileVersionInfoSizeW(
+      file_path_cstr,
+      &ignored
+  );
+
+  if (file_version_info_size == 0) {
+    goto return_bad;
+  }
+
+  /* Get the file version info.*/
+  file_version_info = Mdc_malloc(file_version_info_size);
+
+  if (file_version_info == NULL) {
+    goto return_bad;
+  }
+
+  ignored = 0;
+  is_get_file_version_info_success = GetFileVersionInfoW(
+      file_path_cstr,
+      ignored,
+      file_version_info_size,
+      file_version_info
+  );
+
+  if (!is_get_file_version_info_success) {
+    goto free_file_version_info;
+  }
+
+  /* Gather all of the information into the specified buffer. */
+  is_ver_query_value_success = VerQueryValueW(
+      file_version_info,
+      L"\\",
+      (void**) &temp_fixed_file_info,
+      &temp_file_info_size
+  );
+
+  if (!is_ver_query_value_success) {
+    goto free_file_version_info;
+  }
+
+  /* Copy the file info into the parameter. */
+  *fixed_file_info = *temp_fixed_file_info;
+
+  Mdc_free(file_version_info);
+
+  return fixed_file_info;
+
+free_file_version_info:
+  Mdc_free(file_version_info);
+
+return_bad:
+  return NULL;
+}
+
+VS_FIXEDFILEINFO* Mdc_VS_FIXEDFILEINFO_InitCopy(
+    VS_FIXEDFILEINFO* dest,
+    const VS_FIXEDFILEINFO* src
+) {
+  *dest = *src;
+  return dest;
+}
+
+VS_FIXEDFILEINFO* Mdc_VS_FIXEDFILEINFO_InitMove(
+    VS_FIXEDFILEINFO* dest,
+    VS_FIXEDFILEINFO* src
+) {
+  return Mdc_VS_FIXEDFILEINFO_InitCopy(dest, src);
+}
+
+void Mdc_VS_FIXEDFILEINFO_Deinit(
+    VS_FIXEDFILEINFO* fixed_file_info
+) {
+  /* This is intentionally left blank. */
+}
+VS_FIXEDFILEINFO* Mdc_VS_FIXEDFILEINFO_AssignCopy(
+    VS_FIXEDFILEINFO* dest,
+    const VS_FIXEDFILEINFO* src
+) {
+  if (dest == src) {
+    return dest;
+  }
+
+  *dest = *src;
+  return dest;
+}
+
+VS_FIXEDFILEINFO* Mdc_VS_FIXEDFILEINFO_AssignMove(
+    VS_FIXEDFILEINFO* dest,
+    VS_FIXEDFILEINFO* src
+) {
+  if (dest == src) {
+    return dest;
+  }
+
+  return Mdc_VS_FIXEDFILEINFO_AssignCopy(dest, src);
+}
+
+bool Mdc_VS_FIXEDFILEINFO_Equal(
+    const VS_FIXEDFILEINFO* fixed_file_info1,
+    const VS_FIXEDFILEINFO* fixed_file_info2
+) {
+  int compare_result;
+
+  compare_result = memcmp(
+      fixed_file_info1,
+      fixed_file_info2,
+      sizeof(*fixed_file_info1)
+  );
+
+  return compare_result == 0;
+}
+
+#endif /* defined(_WIN32) || defined(_WIN64) */

--- a/Tests/tests/mdc/filesystem/current_executable_path_tests.c
+++ b/Tests/tests/mdc/filesystem/current_executable_path_tests.c
@@ -27,12 +27,33 @@
  *  to convey the resulting work.
  */
 
-#include "filesystem_tests.h"
+#include "path_windows_tests.h"
 
-#include "filesystem/current_executable_path_tests.h"
-#include "filesystem/path_windows_tests.h"
+#include <stddef.h>
+#include <stdio.h>
 
-void Mdc_Fs_RunTests(void) {
-  Mdc_Fs_CurrentExecutablePath_RunTests();
-  Mdc_Fs_Path_RunTests();
+#include <mdc/filesystem/current_executable_path.h>
+#include <mdc/filesystem/filesystem.h>
+#include <mdc/std/assert.h>
+#include <mdc/malloc/malloc.h>
+#include <mdc/string/basic_string.h>
+
+static void Mdc_Fs_Path_AssertGetCurrentExecutablePath(void) {
+  struct Mdc_Fs_Path current_executable_path;
+  struct Mdc_Fs_Path* init_current_executable_path;
+
+  init_current_executable_path = Mdc_Fs_GetCurrentExecutablePath(
+      &current_executable_path
+  );
+
+  assert(init_current_executable_path == &current_executable_path);
+  assert(!Mdc_Fs_Path_Empty(&current_executable_path));
+
+  Mdc_Fs_Path_Deinit(&current_executable_path);
+
+  assert(Mdc_GetMallocDifference() == 0);
+}
+
+void Mdc_Fs_CurrentExecutablePath_RunTests(void) {
+  Mdc_Fs_Path_AssertGetCurrentExecutablePath();
 }

--- a/Tests/tests/mdc/filesystem/current_executable_path_tests.h
+++ b/Tests/tests/mdc/filesystem/current_executable_path_tests.h
@@ -27,12 +27,9 @@
  *  to convey the resulting work.
  */
 
-#include "filesystem_tests.h"
+#ifndef MDC_TESTS_C_FILESYSTEM_CURRENT_EXECUTABLE_PATH_TESTS_H_
+#define MDC_TESTS_C_FILESYSTEM_CURRENT_EXECUTABLE_PATH_TESTS_H_
 
-#include "filesystem/current_executable_path_tests.h"
-#include "filesystem/path_windows_tests.h"
+void Mdc_Fs_CurrentExecutablePath_RunTests(void);
 
-void Mdc_Fs_RunTests(void) {
-  Mdc_Fs_CurrentExecutablePath_RunTests();
-  Mdc_Fs_Path_RunTests();
-}
+#endif /* MDC_TESTS_C_FILESYSTEM_CURRENT_EXECUTABLE_PATH_TESTS_H_ */


### PR DESCRIPTION
This adds Mdc_Fs_GetCurrentExecutablePath and fixes multiple bugs:
- Missing DLLEXPORT of error functions
- Mdc_Fs_GetCurrentPath fails to allocate correctly
- Mdc malloc functions fail to count free correctly on NULL realloc
- Windows only: Added VS_FIXEDFILEINFO object