### PR TITLE
Add MDC C++98

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@
 *.recipe
 *.vcxproj.FileListAbsolute.txt
 
+# Linker / Executable Secondary Files
+*.exp
+
 # Resource Files
 *.aps
 *.res

--- a/MDC.dsw
+++ b/MDC.dsw
@@ -3,7 +3,7 @@ Microsoft Developer Studio Workspace File, Format Version 6.00
 
 ###############################################################################
 
-Project: "MDC"=.\MDC\MDC.dsp - Package Owner=<4>
+Project: "MDC"=".\MDC\MDC.dsp" - Package Owner=<4>
 
 Package=<5>
 {{{
@@ -15,7 +15,31 @@ Package=<4>
 
 ###############################################################################
 
-Project: "Tests"=.\Tests\Tests.dsp - Package Owner=<4>
+Project: "MDCcpp98"=".\MDCcpp98\MDCcpp98.dsp" - Package Owner=<4>
+
+Package=<5>
+{{{
+}}}
+
+Package=<4>
+{{{
+}}}
+
+###############################################################################
+
+Project: "Tests"=".\Tests\Tests.dsp" - Package Owner=<4>
+
+Package=<5>
+{{{
+}}}
+
+Package=<4>
+{{{
+}}}
+
+###############################################################################
+
+Project: "TestsCpp98"=".\TestsCpp98\TestsCpp98.dsp" - Package Owner=<4>
 
 Package=<5>
 {{{

--- a/MDC.dsw
+++ b/MDC.dsw
@@ -23,6 +23,9 @@ Package=<5>
 
 Package=<4>
 {{{
+    Begin Project Dependency
+    Project_Dep_Name MDC
+    End Project Dependency
 }}}
 
 ###############################################################################
@@ -35,6 +38,9 @@ Package=<5>
 
 Package=<4>
 {{{
+    Begin Project Dependency
+    Project_Dep_Name MDC
+    End Project Dependency
 }}}
 
 ###############################################################################
@@ -47,6 +53,12 @@ Package=<5>
 
 Package=<4>
 {{{
+    Begin Project Dependency
+    Project_Dep_Name MDC
+    End Project Dependency
+    Begin Project Dependency
+    Project_Dep_Name MDCcpp98
+    End Project Dependency
 }}}
 
 ###############################################################################

--- a/MDC/COPYING
+++ b/MDC/COPYING
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<http://www.gnu.org/licenses/>.

--- a/MDC/LICENSE.md
+++ b/MDC/LICENSE.md
@@ -22,28 +22,3 @@ it with any program (or a modified version of that program and its
 libraries), containing parts covered by the terms of an incompatible
 license, the licensors of this Program grant you additional permission
 to convey the resulting work.
-
-# Mir Drualga Common For C++98
-Copyright (C) 2021  Mir Drualga
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU Affero General Public License as published
-by the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Affero General Public License for more details.
-
-You should have received a copy of the GNU Affero General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-Additional permissions under GNU Affero General Public License version 3
-section 7
-
-If you modify this Program, or any covered work, by linking or combining
-it with any program (or a modified version of that program and its
-libraries), containing parts covered by the terms of an incompatible
-license, the licensors of this Program grant you additional permission
-to convey the resulting work.

--- a/MDC/dllexport_define.inc
+++ b/MDC/dllexport_define.inc
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/MDC/dllexport_undefine.inc
+++ b/MDC/dllexport_undefine.inc
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/MDC/include/mdc/error/exit_on_error.h
+++ b/MDC/include/mdc/error/exit_on_error.h
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/MDC/include/mdc/error/exit_on_error.h
+++ b/MDC/include/mdc/error/exit_on_error.h
@@ -27,8 +27,8 @@
  *  to convey the resulting work.
  */
 
-#ifndef MDC_C_EXIT_ON_ERROR_EXIT_ON_ERROR_H_
-#define MDC_C_EXIT_ON_ERROR_EXIT_ON_ERROR_H_
+#ifndef MDC_C_ERROR_EXIT_ON_ERROR_H_
+#define MDC_C_ERROR_EXIT_ON_ERROR_H_
 
 #include "../std/wchar.h"
 #include "../wchar_t/filew.h"
@@ -50,30 +50,38 @@ enum {
 DLLEXPORT void Mdc_Error_ExitOnGeneralError(
     const wchar_t* caption_text,
     const wchar_t* message_format,
-    const wchar_t* file_path_cwstr,
+    const wchar_t* file_path_c_wstr,
     unsigned int line,
     ...
 );
 
+DLLEXPORT void Mdc_Error_ExitOnGeneralErrorV(
+    const wchar_t* caption_text,
+    const wchar_t* message_format,
+    const wchar_t* file_path_c_wstr,
+    unsigned int line,
+    va_list vlist
+);
+
 DLLEXPORT void Mdc_Error_ExitOnConstantMappingError(
-    const wchar_t* file_path_cwstr,
+    const wchar_t* file_path_c_wstr,
     unsigned int line,
     int value
 );
 
 DLLEXPORT void Mdc_Error_ExitOnMemoryAllocError(
-    const wchar_t* file_path_cwstr,
+    const wchar_t* file_path_c_wstr,
     unsigned int line
 );
 
 DLLEXPORT void Mdc_Error_ExitOnMdcFunctionError(
-    const wchar_t* file_path_cwstr,
+    const wchar_t* file_path_c_wstr,
     unsigned int line,
     const wchar_t* function_name
 );
 
 DLLEXPORT void Mdc_Error_ExitOnStaticInitError(
-    const wchar_t* file_path_cwstr,
+    const wchar_t* file_path_c_wstr,
     unsigned int line
 );
 
@@ -93,4 +101,4 @@ DLLEXPORT void Mdc_Error_ExitOnWindowsFunctionError(
 #endif /* __cplusplus */
 
 #include "../../../dllexport_undefine.inc"
-#endif /* MDC_C_EXIT_ON_ERROR_EXIT_ON_ERROR_H_ */
+#endif /* MDC_C_ERROR_EXIT_ON_ERROR_H_ */

--- a/MDC/include/mdc/malloc/malloc.h
+++ b/MDC/include/mdc/malloc/malloc.h
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/MDC/include/mdc/std/assert.h
+++ b/MDC/include/mdc/std/assert.h
@@ -37,15 +37,17 @@
 
 #if !defined(static_assert) && \
     (__STDC_VERSION__ < 201112L \
-      || __cpluplus < 201103L \
-      || _MSC_VER < 1600)
+        && __cpluplus < 201103L \
+        && _MSVC_LANG < 201103L) \
+    || _MSC_VER < 1600
 
 /* Assert hackarounds fail to work with VC++ 6. */
 #define static_assert(expression, message)
 
-#endif /* !defined(static_assert) && \
+#endif /*  !defined(static_assert) && \
     (__STDC_VERSION__ < 201112L \
-      || __cpluplus < 201103L \
-      || _MSC_VER < 1600) */
+        && __cpluplus < 201103L \
+        && _MSVC_LANG < 201103L) \
+    || _MSC_VER < 1600 */
 
 #endif /* MDC_C_STD_ASSERT_H_ */

--- a/MDC/include/mdc/std/assert.h
+++ b/MDC/include/mdc/std/assert.h
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/MDC/include/mdc/std/stdbool.h
+++ b/MDC/include/mdc/std/stdbool.h
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/MDC/include/mdc/std/stdint.h
+++ b/MDC/include/mdc/std/stdint.h
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/MDC/include/mdc/std/threads.h
+++ b/MDC/include/mdc/std/threads.h
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/MDC/include/mdc/std/wchar.h
+++ b/MDC/include/mdc/std/wchar.h
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/MDC/include/mdc/wchar_t/filew.h
+++ b/MDC/include/mdc/wchar_t/filew.h
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/MDC/include/mdc/wchar_t/wide_decoding.h
+++ b/MDC/include/mdc/wchar_t/wide_decoding.h
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/MDC/include/mdc/wchar_t/wide_encoding.h
+++ b/MDC/include/mdc/wchar_t/wide_encoding.h
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/MDC/src/mdc/error/exit_on_error.c
+++ b/MDC/src/mdc/error/exit_on_error.c
@@ -46,31 +46,49 @@ static wchar_t error_message[Mdc_Error_kErrorMessageCapacity];
 void Mdc_Error_ExitOnGeneralError(
     const wchar_t* caption_text,
     const wchar_t* message_format,
-    const wchar_t* file_path_cwstr,
+    const wchar_t* file_path_c_wstr,
     unsigned int line,
     ...
 ) {
   va_list args;
 
+  va_start(args, line);
+
+  Mdc_Error_ExitOnGeneralErrorV(
+      caption_text,
+      message_format,
+      file_path_c_wstr,
+      line,
+      args
+  );
+
+  va_end(args);
+}
+
+void Mdc_Error_ExitOnGeneralErrorV(
+    const wchar_t* caption_text,
+    const wchar_t* message_format,
+    const wchar_t* file_path_c_wstr,
+    unsigned int line,
+    va_list vlist
+) {
   _snwprintf(
       error_message_format,
       Mdc_Error_kErrorMessageCapacity,
       kErrorMessageFormat,
-      file_path_cwstr,
+      file_path_c_wstr,
       line,
       message_format
   );
 
   error_message_format[Mdc_Error_kErrorMessageCapacity - 1] = L'\0';
 
-  va_start(args, line);
   _vsnwprintf(
       error_message,
       Mdc_Error_kErrorMessageCapacity,
       error_message_format,
-      args
+      vlist
   );
-  va_end(args);
 
   error_message[Mdc_Error_kErrorMessageCapacity - 1] = L'\0';
 
@@ -85,59 +103,59 @@ void Mdc_Error_ExitOnGeneralError(
 }
 
 void Mdc_Error_ExitOnConstantMappingError(
-    const wchar_t* file_path_cwstr,
+    const wchar_t* file_path_c_wstr,
     unsigned int line,
     int value
 ) {
   Mdc_Error_ExitOnGeneralError(
       L"Error",
       L"Constant with value %d could not be mapped.",
-      file_path_cwstr,
+      file_path_c_wstr,
       line,
       value
   );
 }
 
 void Mdc_Error_ExitOnMemoryAllocError(
-    const wchar_t* file_path_cwstr,
+    const wchar_t* file_path_c_wstr,
     unsigned int line
 ) {
   Mdc_Error_ExitOnGeneralError(
       L"Error",
       L"Memory allocation error.",
-      file_path_cwstr,
+      file_path_c_wstr,
       line
   );
 }
 
 void Mdc_Error_ExitOnMdcFunctionError(
-    const wchar_t* file_path_cwstr,
+    const wchar_t* file_path_c_wstr,
     unsigned int line,
     const wchar_t* function_name
 ) {
   Mdc_Error_ExitOnGeneralError(
       L"Error",
       L"MDC function error on %ls.",
-      file_path_cwstr,
+      file_path_c_wstr,
       line,
       function_name
   );
 }
 
 void Mdc_Error_ExitOnStaticInitError(
-    const wchar_t* file_path_cwstr,
+    const wchar_t* file_path_c_wstr,
     unsigned int line
 ) {
   Mdc_Error_ExitOnGeneralError(
       L"Error",
       L"Static init error.",
-      file_path_cwstr,
+      file_path_c_wstr,
       line
   );
 }
 
 void Mdc_Error_ExitOnWindowsFunctionError(
-    const wchar_t* file_path_cwstr,
+    const wchar_t* file_path_c_wstr,
     unsigned int line,
     const wchar_t* function_name,
     DWORD last_error
@@ -145,7 +163,7 @@ void Mdc_Error_ExitOnWindowsFunctionError(
   Mdc_Error_ExitOnGeneralError(
       L"Error",
       L"Windows function error on %ls with error code 0x%X.",
-      file_path_cwstr,
+      file_path_c_wstr,
       line,
       function_name,
       last_error

--- a/MDC/src/mdc/error/exit_on_error.c
+++ b/MDC/src/mdc/error/exit_on_error.c
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/MDC/src/mdc/malloc/malloc.c
+++ b/MDC/src/mdc/malloc/malloc.c
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/MDC/src/mdc/std/threads/call_once.c
+++ b/MDC/src/mdc/std/threads/call_once.c
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/MDC/src/mdc/std/threads/cond.c
+++ b/MDC/src/mdc/std/threads/cond.c
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/MDC/src/mdc/std/threads/mutex.c
+++ b/MDC/src/mdc/std/threads/mutex.c
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/MDC/src/mdc/std/threads/threads.c
+++ b/MDC/src/mdc/std/threads/threads.c
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/MDC/src/mdc/std/wchar/wchar.c
+++ b/MDC/src/mdc/std/wchar/wchar.c
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/MDC/src/mdc/wchar_t/wide_decoding.c
+++ b/MDC/src/mdc/wchar_t/wide_decoding.c
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/MDC/src/mdc/wchar_t/wide_encoding.c
+++ b/MDC/src/mdc/wchar_t/wide_encoding.c
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/MDCcpp98/COPYING
+++ b/MDCcpp98/COPYING
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<http://www.gnu.org/licenses/>.

--- a/MDCcpp98/LICENSE.md
+++ b/MDCcpp98/LICENSE.md
@@ -1,0 +1,24 @@
+# Mir Drualga Common For C++98
+Copyright (C) 2021  Mir Drualga
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU Affero General Public License version 3
+section 7
+
+If you modify this Program, or any covered work, by linking or combining
+it with any program (or a modified version of that program and its
+libraries), containing parts covered by the terms of an incompatible
+license, the licensors of this Program grant you additional permission
+to convey the resulting work.

--- a/MDCcpp98/MDCcpp98.dsp
+++ b/MDCcpp98/MDCcpp98.dsp
@@ -102,6 +102,10 @@ SOURCE=.\include\mdc\error\exit_on_error.hpp
 # PROP Default_Filter ""
 # Begin Source File
 
+SOURCE=.\include\mdc\std\condition_variable.hpp
+# End Source File
+# Begin Source File
+
 SOURCE=.\include\mdc\std\mutex.hpp
 # End Source File
 # Begin Source File
@@ -136,6 +140,18 @@ SOURCE=.\include\mdc\wchar_t\wide_encoding.hpp
 # Begin Group "std_cpp"
 
 # PROP Default_Filter ""
+# Begin Group "condition_variable_cpp"
+
+# PROP Default_Filter ""
+# Begin Source File
+
+SOURCE=.\src\mdc\std\condition_variable\condition_variable.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\mdc\std\condition_variable\condition_variable_any.cpp
+# End Source File
+# End Group
 # Begin Group "mutex_cpp"
 
 # PROP Default_Filter ""

--- a/MDCcpp98/MDCcpp98.dsp
+++ b/MDCcpp98/MDCcpp98.dsp
@@ -136,6 +136,10 @@ SOURCE=.\include\mdc\wchar_t\wide_encoding.hpp
 # Begin Group "error_cpp"
 
 # PROP Default_Filter ""
+# Begin Source File
+
+SOURCE=.\src\mdc\error\exit_on_error.cpp
+# End Source File
 # End Group
 # Begin Group "std_cpp"
 

--- a/MDCcpp98/MDCcpp98.dsp
+++ b/MDCcpp98/MDCcpp98.dsp
@@ -1,0 +1,156 @@
+# Microsoft Developer Studio Project File - Name="MDCcpp98" - Package Owner=<4>
+# Microsoft Developer Studio Generated Build File, Format Version 6.00
+# ** DO NOT EDIT **
+
+# TARGTYPE "Win32 (x86) Static Library" 0x0104
+
+CFG=MDCcpp98 - Win32 Debug
+!MESSAGE This is not a valid makefile. To build this project using NMAKE,
+!MESSAGE use the Export Makefile command and run
+!MESSAGE 
+!MESSAGE NMAKE /f "MDCcpp98.mak".
+!MESSAGE 
+!MESSAGE You can specify a configuration when running NMAKE
+!MESSAGE by defining the macro CFG on the command line. For example:
+!MESSAGE 
+!MESSAGE NMAKE /f "MDCcpp98.mak" CFG="MDCcpp98 - Win32 Debug"
+!MESSAGE 
+!MESSAGE Possible choices for configuration are:
+!MESSAGE 
+!MESSAGE "MDCcpp98 - Win32 Release" (based on "Win32 (x86) Static Library")
+!MESSAGE "MDCcpp98 - Win32 Debug" (based on "Win32 (x86) Static Library")
+!MESSAGE 
+
+# Begin Project
+# PROP AllowPerConfigDependencies 0
+# PROP Scc_ProjName ""
+# PROP Scc_LocalPath ""
+CPP=cl.exe
+RSC=rc.exe
+
+!IF  "$(CFG)" == "MDCcpp98 - Win32 Release"
+
+# PROP BASE Use_MFC 0
+# PROP BASE Use_Debug_Libraries 0
+# PROP BASE Output_Dir "Release"
+# PROP BASE Intermediate_Dir "Release"
+# PROP BASE Target_Dir ""
+# PROP Use_MFC 0
+# PROP Use_Debug_Libraries 0
+# PROP Output_Dir "Release"
+# PROP Intermediate_Dir "Release"
+# PROP Target_Dir ""
+# ADD BASE CPP /nologo /W3 /GX /O2 /D "WIN32" /D "NDEBUG" /D "_MBCS" /D "_LIB" /YX /FD /c
+# ADD CPP /nologo /MD /W3 /GX /O2 /D "WIN32" /D "NDEBUG" /D "_LIB" /D "_UNICODE" /D "UNICODE" /YX /FD /c
+# ADD BASE RSC /l 0x409 /d "NDEBUG"
+# ADD RSC /l 0x409 /d "NDEBUG"
+BSC32=bscmake.exe
+# ADD BASE BSC32 /nologo
+# ADD BSC32 /nologo
+LIB32=link.exe -lib
+# ADD BASE LIB32 /nologo
+# ADD LIB32 /nologo
+
+!ELSEIF  "$(CFG)" == "MDCcpp98 - Win32 Debug"
+
+# PROP BASE Use_MFC 0
+# PROP BASE Use_Debug_Libraries 1
+# PROP BASE Output_Dir "Debug"
+# PROP BASE Intermediate_Dir "Debug"
+# PROP BASE Target_Dir ""
+# PROP Use_MFC 0
+# PROP Use_Debug_Libraries 1
+# PROP Output_Dir "Debug"
+# PROP Intermediate_Dir "Debug"
+# PROP Target_Dir ""
+# ADD BASE CPP /nologo /W3 /Gm /GX /ZI /Od /D "WIN32" /D "_DEBUG" /D "_MBCS" /D "_LIB" /YX /FD /GZ /c
+# ADD CPP /nologo /MDd /W3 /Gm /GX /ZI /Od /D "WIN32" /D "_DEBUG" /D "_LIB" /D "_UNICODE" /D "UNICODE" /YX /FD /GZ /c
+# ADD BASE RSC /l 0x409 /d "_DEBUG"
+# ADD RSC /l 0x409 /d "_DEBUG"
+BSC32=bscmake.exe
+# ADD BASE BSC32 /nologo
+# ADD BSC32 /nologo
+LIB32=link.exe -lib
+# ADD BASE LIB32 /nologo
+# ADD LIB32 /nologo
+
+!ENDIF 
+
+# Begin Target
+
+# Name "MDCcpp98 - Win32 Release"
+# Name "MDCcpp98 - Win32 Debug"
+# Begin Group "Files"
+
+# PROP Default_Filter ""
+# Begin Group "include"
+
+# PROP Default_Filter ""
+# Begin Group "mdc_hpp"
+
+# PROP Default_Filter ""
+# Begin Group "error_hpp"
+
+# PROP Default_Filter ""
+# Begin Source File
+
+SOURCE=.\include\mdc\error\exit_on_error.hpp
+# End Source File
+# End Group
+# Begin Group "std_hpp"
+
+# PROP Default_Filter ""
+# Begin Source File
+
+SOURCE=.\include\mdc\std\threads.hpp
+# End Source File
+# End Group
+# Begin Group "wchar_t_hpp"
+
+# PROP Default_Filter ""
+# Begin Source File
+
+SOURCE=.\include\mdc\wchar_t\wide_decoding.hpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\include\mdc\wchar_t\wide_encoding.hpp
+# End Source File
+# End Group
+# End Group
+# End Group
+# Begin Group "src"
+
+# PROP Default_Filter ""
+# Begin Group "mdc_cpp"
+
+# PROP Default_Filter ""
+# Begin Group "error_cpp"
+
+# PROP Default_Filter ""
+# End Group
+# Begin Group "std_cpp"
+
+# PROP Default_Filter ""
+# Begin Source File
+
+SOURCE=.\src\mdc\std\threads.cpp
+# End Source File
+# End Group
+# Begin Group "wchar_t_cpp"
+
+# PROP Default_Filter ""
+# Begin Source File
+
+SOURCE=.\src\mdc\wchar_t\wide_decoding.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\mdc\wchar_t\wide_encoding.cpp
+# End Source File
+# End Group
+# End Group
+# End Group
+# End Group
+# End Target
+# End Project

--- a/MDCcpp98/MDCcpp98.dsp
+++ b/MDCcpp98/MDCcpp98.dsp
@@ -102,6 +102,10 @@ SOURCE=.\include\mdc\error\exit_on_error.hpp
 # PROP Default_Filter ""
 # Begin Source File
 
+SOURCE=.\include\mdc\std\mutex.hpp
+# End Source File
+# Begin Source File
+
 SOURCE=.\include\mdc\std\threads.hpp
 # End Source File
 # End Group
@@ -131,6 +135,23 @@ SOURCE=.\include\mdc\wchar_t\wide_encoding.hpp
 # End Group
 # Begin Group "std_cpp"
 
+# PROP Default_Filter ""
+# Begin Group "mutex_cpp"
+
+# PROP Default_Filter ""
+# Begin Source File
+
+SOURCE=.\src\mdc\std\mutex\call_once.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\mdc\std\mutex\mutex.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\mdc\std\mutex\recursive_mutex.cpp
+# End Source File
+# End Group
 # Begin Group "threads_cpp"
 
 # PROP Default_Filter ""

--- a/MDCcpp98/MDCcpp98.dsp
+++ b/MDCcpp98/MDCcpp98.dsp
@@ -131,11 +131,14 @@ SOURCE=.\include\mdc\wchar_t\wide_encoding.hpp
 # End Group
 # Begin Group "std_cpp"
 
+# Begin Group "threads_cpp"
+
 # PROP Default_Filter ""
 # Begin Source File
 
-SOURCE=.\src\mdc\std\threads.cpp
+SOURCE=.\src\mdc\std\threads\threads.cpp
 # End Source File
+# End Group
 # End Group
 # Begin Group "wchar_t_cpp"
 

--- a/MDCcpp98/MDCcpp98.dsp
+++ b/MDCcpp98/MDCcpp98.dsp
@@ -72,7 +72,7 @@ BSC32=bscmake.exe
 # ADD BSC32 /nologo
 LIB32=link.exe -lib
 # ADD BASE LIB32 /nologo
-# ADD LIB32 /nologo
+# ADD LIB32 /nologo /out:"Debug\MDCcpp98D.lib"
 
 !ENDIF 
 

--- a/MDCcpp98/dllexport_define.inc
+++ b/MDCcpp98/dllexport_define.inc
@@ -1,0 +1,44 @@
+/**
+ * Mir Drualga Common For C++98
+ * Copyright (C) 2021  Mir Drualga
+ *
+ * This file is part of Mir Drualga Common For C++98.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any program (or a modified version of that program and its
+ *  libraries), containing parts covered by the terms of an incompatible
+ *  license, the licensors of this Program grant you additional permission
+ *  to convey the resulting work.
+ */
+
+#if defined(MDC_CPP98_DLLEXPORT)
+  #if defined(_MSC_VER)
+    #define DLLEXPORT __declspec(dllexport)
+  #elif defined(__GNUC__)
+    #define DLLEXPORT __attribute__((visibility("default")))
+  #endif
+#elif defined(MDC_CPP98_DLLIMPORT)
+  #if defined(_MSC_VER)
+    #define DLLEXPORT __declspec(dllimport)
+  #elif defined(__GNUC__)
+    #define DLLEXPORT
+  #endif
+#else
+  #define DLLEXPORT
+#endif

--- a/MDCcpp98/dllexport_undefine.inc
+++ b/MDCcpp98/dllexport_undefine.inc
@@ -1,0 +1,30 @@
+/**
+ * Mir Drualga Common For C++98
+ * Copyright (C) 2021  Mir Drualga
+ *
+ * This file is part of Mir Drualga Common For C++98.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any program (or a modified version of that program and its
+ *  libraries), containing parts covered by the terms of an incompatible
+ *  license, the licensors of this Program grant you additional permission
+ *  to convey the resulting work.
+ */
+
+#undef DLLEXPORT

--- a/MDCcpp98/include/mdc/error/exit_on_error.hpp
+++ b/MDCcpp98/include/mdc/error/exit_on_error.hpp
@@ -1,0 +1,152 @@
+/**
+ * Mir Drualga Common For C++98
+ * Copyright (C) 2021  Mir Drualga
+ *
+ * This file is part of Mir Drualga Common For C++98.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any program (or a modified version of that program and its
+ *  libraries), containing parts covered by the terms of an incompatible
+ *  license, the licensors of this Program grant you additional permission
+ *  to convey the resulting work.
+ */
+
+#ifndef MDC_CPP98_ERROR_EXIT_ON_ERROR_HPP_
+#define MDC_CPP98_ERROR_EXIT_ON_ERROR_HPP_
+
+#include <stdarg.h>
+
+#include <mdc/error/exit_on_error.h>
+#include <mdc/wchar_t/filew.h>
+
+#if defined(_WIN32) || defined(_WIN64)
+  #include <windows.h>
+#endif /* defined(_WIN32) || defined(_WIN64) */
+
+namespace mdc {
+namespace error {
+
+enum {
+  kErrorMessageCapacity = Mdc_Error_kErrorMessageCapacity,
+};
+
+void ExitOnGeneralError(
+    const wchar_t* caption_text,
+    const wchar_t* message_format,
+    const wchar_t* file_path_c_wstr,
+    unsigned int line,
+    ...
+) {
+  va_list args;
+
+  va_start(args, line);
+
+  Mdc_Error_ExitOnGeneralErrorV(
+      caption_text,
+      message_format,
+      file_path_c_wstr,
+      line,
+      args
+  );
+
+  va_end(args);
+}
+
+void ExitOnGeneralErrorV(
+    const wchar_t* caption_text,
+    const wchar_t* message_format,
+    const wchar_t* file_path_c_wstr,
+    unsigned int line,
+    va_list args
+) {
+  Mdc_Error_ExitOnGeneralErrorV(
+      caption_text,
+      message_format,
+      file_path_c_wstr,
+      line,
+      args
+  );
+}
+
+void ExitOnConstantMappingError(
+    const wchar_t* file_path_c_wstr,
+    unsigned int line,
+    int value
+) {
+  Mdc_Error_ExitOnConstantMappingError(
+      file_path_c_wstr,
+      line,
+      value
+  );
+}
+
+void ExitOnMemoryAllocError(
+    const wchar_t* file_path_c_wstr,
+    unsigned int line
+) {
+  Mdc_Error_ExitOnMemoryAllocError(
+      file_path_c_wstr,
+      line
+  );
+}
+
+void ExitOnMdcFunctionError(
+    const wchar_t* file_path_c_wstr,
+    unsigned int line,
+    const wchar_t* function_name
+) {
+  Mdc_Error_ExitOnMdcFunctionError(
+      file_path_c_wstr,
+      line,
+      function_name
+  );
+}
+
+void ExitOnStaticInitError(
+    const wchar_t* file_path_c_wstr,
+    unsigned int line
+) {
+  Mdc_Error_ExitOnStaticInitError(
+      file_path_c_wstr,
+      line
+  );
+}
+
+#if defined(_WIN32) || defined(_WIN64)
+
+void ExitOnWindowsFunctionError(
+    const wchar_t* file_path_c_wstr,
+    unsigned int line,
+    const wchar_t* function_name,
+    DWORD last_error
+) {
+  Mdc_Error_ExitOnWindowsFunctionError(
+      file_path_c_wstr,
+      line,
+      function_name,
+      last_error
+  );
+}
+
+#endif /* defined(_WIN32) || defined(_WIN64) */
+
+} // namespace error
+} // namespace mdc
+
+#endif /* MDC_CPP98_ERROR_EXIT_ON_ERROR_HPP_ */

--- a/MDCcpp98/include/mdc/std/condition_variable.hpp
+++ b/MDCcpp98/include/mdc/std/condition_variable.hpp
@@ -75,6 +75,36 @@ class condition_variable {
   condition_variable& operator=(const condition_variable&);
 };
 
+class condition_variable_any {
+ public:
+  condition_variable_any();
+
+  ~condition_variable_any();
+
+  void notify_one() throw();
+
+  void notify_all() throw();
+
+  template <class Lock>
+  void wait(Lock& lock) {
+    ::cnd_wait(&this->condition_variable_, &lock.mutex()->native_handle());
+  }
+
+  template <class Lock, class Predicate>
+  void wait(Lock& lock, Predicate pred) {
+    while (!pred()) {
+      wait(lock);
+    }
+  }
+
+ private:
+  cnd_t condition_variable_;
+
+  // Intentionally unimplemented to "delete" them.
+  condition_variable_any(const condition_variable_any&);
+  condition_variable_any& operator=(const condition_variable_any&);
+};
+
 } // namespace std
 
 #include "../../../dllexport_undefine.inc"

--- a/MDCcpp98/include/mdc/std/condition_variable.hpp
+++ b/MDCcpp98/include/mdc/std/condition_variable.hpp
@@ -68,7 +68,7 @@ class condition_variable {
   }
 
  private:
-  cnd_t condition_variable_;
+  ::cnd_t condition_variable_;
 
   // Intentionally unimplemented to "delete" them.
   condition_variable(const condition_variable&);
@@ -98,7 +98,7 @@ class condition_variable_any {
   }
 
  private:
-  cnd_t condition_variable_;
+  ::cnd_t condition_variable_;
 
   // Intentionally unimplemented to "delete" them.
   condition_variable_any(const condition_variable_any&);

--- a/MDCcpp98/include/mdc/std/condition_variable.hpp
+++ b/MDCcpp98/include/mdc/std/condition_variable.hpp
@@ -30,13 +30,17 @@
 #ifndef MDC_CPP98_STD_CONDITION_VARIABLE_HPP_
 #define MDC_CPP98_STD_CONDITION_VARIABLE_HPP_
 
+#if __cplusplus >= 201103L || _MSVC_LANG >= 201103L
+
+#include <condition_variable>
+
+#else
+
 #include <mdc/std/threads.h>
 
 #include "mutex.hpp"
 
 #include "../../../dllexport_define.inc"
-
-#if __cplusplus < 201103L && _MSVC_LANG < 201103L
 
 namespace std {
 
@@ -73,7 +77,7 @@ class condition_variable {
 
 } // namespace std
 
-#endif // __cplusplus < 201103L && _MSVC_LANG < 201103L
-
 #include "../../../dllexport_undefine.inc"
+#endif // __cplusplus >= 201103L || _MSVC_LANG >= 201103L
+
 #endif /* MDC_CPP98_STD_CONDITION_VARIABLE_HPP_ */

--- a/MDCcpp98/include/mdc/std/condition_variable.hpp
+++ b/MDCcpp98/include/mdc/std/condition_variable.hpp
@@ -1,0 +1,79 @@
+/**
+ * Mir Drualga Common For C++98
+ * Copyright (C) 2021  Mir Drualga
+ *
+ * This file is part of Mir Drualga Common For C++98.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any program (or a modified version of that program and its
+ *  libraries), containing parts covered by the terms of an incompatible
+ *  license, the licensors of this Program grant you additional permission
+ *  to convey the resulting work.
+ */
+
+#ifndef MDC_CPP98_STD_CONDITION_VARIABLE_HPP_
+#define MDC_CPP98_STD_CONDITION_VARIABLE_HPP_
+
+#include <mdc/std/threads.h>
+
+#include "mutex.hpp"
+
+#include "../../../dllexport_define.inc"
+
+#if __cplusplus < 201103L && _MSVC_LANG < 201103L
+
+namespace std {
+
+/**
+ * Condition variables
+ */
+
+class condition_variable {
+ public:
+  condition_variable();
+
+  ~condition_variable();
+
+  void notify_one() throw();
+
+  void notify_all() throw();
+
+  void wait(unique_lock<mutex>& lock);
+
+  template <class Predicate>
+  void wait(unique_lock<mutex>& lock, Predicate pred) {
+    while (!pred()) {
+      wait(lock);
+    }
+  }
+
+ private:
+  cnd_t condition_variable_;
+
+  // Intentionally unimplemented to "delete" them.
+  condition_variable(const condition_variable&);
+  condition_variable& operator=(const condition_variable&);
+};
+
+} // namespace std
+
+#endif // __cplusplus < 201103L && _MSVC_LANG < 201103L
+
+#include "../../../dllexport_undefine.inc"
+#endif /* MDC_CPP98_STD_CONDITION_VARIABLE_HPP_ */

--- a/MDCcpp98/include/mdc/std/condition_variable.hpp
+++ b/MDCcpp98/include/mdc/std/condition_variable.hpp
@@ -48,7 +48,7 @@ namespace std {
  * Condition variables
  */
 
-class condition_variable {
+class DLLEXPORT condition_variable {
  public:
   condition_variable();
 
@@ -75,7 +75,7 @@ class condition_variable {
   condition_variable& operator=(const condition_variable&);
 };
 
-class condition_variable_any {
+class DLLEXPORT condition_variable_any {
  public:
   condition_variable_any();
 

--- a/MDCcpp98/include/mdc/std/mutex.hpp
+++ b/MDCcpp98/include/mdc/std/mutex.hpp
@@ -48,7 +48,7 @@ namespace std {
  * Mutual exclusion
  */
 
-class mutex {
+class DLLEXPORT mutex {
  public:
   typedef ::mtx_t native_handle_type;
 
@@ -72,7 +72,7 @@ class mutex {
   mutex& operator=(const mutex&);
 };
 
-class recursive_mutex {
+class DLLEXPORT recursive_mutex {
  public:
   typedef ::mtx_t native_handle_type;
 
@@ -228,7 +228,7 @@ class unique_lock {
  * Call once
  */
 
-class once_flag {
+class DLLEXPORT once_flag {
  public:
   once_flag() throw();
 

--- a/MDCcpp98/include/mdc/std/mutex.hpp
+++ b/MDCcpp98/include/mdc/std/mutex.hpp
@@ -30,13 +30,17 @@
 #ifndef MDC_CPP98_STD_MUTEX_HPP_
 #define MDC_CPP98_STD_MUTEX_HPP_
 
+#if __cplusplus >= 201103L || _MSVC_LANG >= 201103L
+
+#include <mutex>
+
+#else
+
 #include <stddef.h>
 
 #include <mdc/std/threads.h>
 
 #include "../../../dllexport_define.inc"
-
-#if __cplusplus < 201103L && _MSVC_LANG < 201103L
 
 namespace std {
 
@@ -234,7 +238,7 @@ class once_flag {
 
 } // namespace std
 
-#endif // __cplusplus < 201103L && _MSVC_LANG < 201103L
+#endif // __cplusplus >= 201103L || _MSVC_LANG >= 201103L
 
 #include "../../../dllexport_undefine.inc"
 #endif /* MDC_CPP98_STD_MUTEX_HPP_ */

--- a/MDCcpp98/include/mdc/std/mutex.hpp
+++ b/MDCcpp98/include/mdc/std/mutex.hpp
@@ -1,0 +1,136 @@
+/**
+ * Mir Drualga Common For C++98
+ * Copyright (C) 2021  Mir Drualga
+ *
+ * This file is part of Mir Drualga Common For C++98.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any program (or a modified version of that program and its
+ *  libraries), containing parts covered by the terms of an incompatible
+ *  license, the licensors of this Program grant you additional permission
+ *  to convey the resulting work.
+ */
+
+#ifndef MDC_CPP98_STD_MUTEX_HPP_
+#define MDC_CPP98_STD_MUTEX_HPP_
+
+#include <mdc/std/threads.h>
+
+#include "../../../dllexport_define.inc"
+
+#if __cplusplus < 201103L && _MSVC_LANG < 201103L
+
+namespace std {
+
+/**
+ * Mutual exclusion
+ */
+
+class mutex {
+ public:
+  mutex() throw();
+
+  ~mutex();
+
+  void lock();
+
+  bool try_lock();
+
+  void unlock();
+
+ private:
+  ::mtx_t mutex_;
+
+  // Intentionally unimplemented to "delete" them.
+  mutex(const mutex&);
+  mutex& operator=(const mutex&);
+};
+
+class recursive_mutex {
+ public:
+  recursive_mutex() throw();
+
+  ~recursive_mutex();
+
+  void lock();
+
+  bool try_lock();
+
+  void unlock();
+
+ private:
+  ::mtx_t mutex_;
+
+  // Intentionally unimplemented to "delete" them.
+  recursive_mutex(const recursive_mutex&);
+  recursive_mutex& operator=(const recursive_mutex&);
+};
+
+/**
+ * Generic mutex management
+ */
+
+template <class Mutex>
+class lock_guard {
+ public:
+  typedef Mutex mutex_type;
+
+  explicit lock_guard(mutex_type& m) {
+    this->mutex_ = m;
+    m.lock();
+  }
+
+  ~lock_guard() {
+    mutex_.unlock();
+  }
+
+ private:
+  mutex_type& mutex_;
+
+  // Intentionally unimplemented to "delete" them.
+  lock_guard(const lock_guard&);
+  lock_guard& operator=(const lock_guard&);
+};
+
+/**
+ * Call once
+ */
+
+class once_flag {
+ public:
+  once_flag() throw();
+
+  friend void call_once(once_flag& flag, void (*func)(void));
+
+ private:
+  static const ::once_flag kDefaultInit;
+
+  ::once_flag once_flag_;
+
+  // Intentionally unimplemented to "delete" them.
+  once_flag(const once_flag&);
+  once_flag& operator=(const once_flag&);
+};
+
+} // namespace std
+
+#endif // __cplusplus < 201103L && _MSVC_LANG < 201103L
+
+#include "../../../dllexport_undefine.inc"
+#endif /* MDC_CPP98_STD_MUTEX_HPP_ */

--- a/MDCcpp98/include/mdc/std/mutex.hpp
+++ b/MDCcpp98/include/mdc/std/mutex.hpp
@@ -50,6 +50,8 @@ namespace std {
 
 class mutex {
  public:
+  typedef ::mtx_t native_handle_type;
+
   mutex() throw();
 
   ~mutex();
@@ -60,8 +62,10 @@ class mutex {
 
   void unlock();
 
+  native_handle_type native_handle();
+
  private:
-  ::mtx_t mutex_;
+  native_handle_type mutex_;
 
   // Intentionally unimplemented to "delete" them.
   mutex(const mutex&);
@@ -70,6 +74,8 @@ class mutex {
 
 class recursive_mutex {
  public:
+  typedef ::mtx_t native_handle_type;
+
   recursive_mutex() throw();
 
   ~recursive_mutex();
@@ -80,8 +86,10 @@ class recursive_mutex {
 
   void unlock();
 
+  native_handle_type native_handle();
+
  private:
-  ::mtx_t mutex_;
+  native_handle_type mutex_;
 
   // Intentionally unimplemented to "delete" them.
   recursive_mutex(const recursive_mutex&);

--- a/MDCcpp98/include/mdc/std/mutex.hpp
+++ b/MDCcpp98/include/mdc/std/mutex.hpp
@@ -246,7 +246,7 @@ class once_flag {
 
 } // namespace std
 
+#include "../../../dllexport_undefine.inc"
 #endif // __cplusplus >= 201103L || _MSVC_LANG >= 201103L
 
-#include "../../../dllexport_undefine.inc"
 #endif /* MDC_CPP98_STD_MUTEX_HPP_ */

--- a/MDCcpp98/include/mdc/std/threads.hpp
+++ b/MDCcpp98/include/mdc/std/threads.hpp
@@ -52,8 +52,8 @@ class DLLEXPORT thread {
  private:
   thrd_t thread_;
 
+  // Intentionally unimplemented to "delete" them.
   thread();
-
   thread(const thread&);
 };
 

--- a/MDCcpp98/include/mdc/std/threads.hpp
+++ b/MDCcpp98/include/mdc/std/threads.hpp
@@ -30,11 +30,15 @@
 #ifndef MDC_CPP98_STD_THREADS_HPP_
 #define MDC_CPP98_STD_THREADS_HPP_
 
+#if __cplusplus >= 201103L || _MSVC_LANG >= 201103L
+
+#include <thread>
+
+#else
+
 #include <mdc/std/threads.h>
 
 #include "../../../dllexport_define.inc"
-
-#if __cplusplus < 201103L && _MSVC_LANG < 201103L
 
 namespace std {
 
@@ -59,7 +63,8 @@ class DLLEXPORT thread {
 
 } // namespace std
 
-#endif // __cplusplus < 201103L && _MSVC_LANG < 201103L
 
 #include "../../../dllexport_undefine.inc"
+#endif // __cplusplus >= 201103L || _MSVC_LANG >= 201103L
+
 #endif /* MDC_CPP98_STD_THREADS_HPP_ */

--- a/MDCcpp98/include/mdc/std/threads.hpp
+++ b/MDCcpp98/include/mdc/std/threads.hpp
@@ -1,0 +1,65 @@
+/**
+ * Mir Drualga Common For C++98
+ * Copyright (C) 2021  Mir Drualga
+ *
+ * This file is part of Mir Drualga Common For C++98.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any program (or a modified version of that program and its
+ *  libraries), containing parts covered by the terms of an incompatible
+ *  license, the licensors of this Program grant you additional permission
+ *  to convey the resulting work.
+ */
+
+#ifndef MDC_CPP98_STD_THREADS_HPP_
+#define MDC_CPP98_STD_THREADS_HPP_
+
+#include <mdc/std/threads.h>
+
+#include "../../../dllexport_define.inc"
+
+#if __cplusplus < 201103L && _MSVC_LANG < 201103L
+
+namespace std {
+
+class DLLEXPORT thread {
+ public:
+
+  explicit thread(int (*func)(void*), void* arg);
+
+  void join();
+
+  void detach();
+
+  void swap(thread& other) throw();
+
+ private:
+  thrd_t thread_;
+
+  thread();
+
+  thread(const thread&);
+};
+
+} // namespace std
+
+#endif // __cplusplus < 201103L && _MSVC_LANG < 201103L
+
+#include "../../../dllexport_undefine.inc"
+#endif /* MDC_CPP98_STD_THREADS_HPP_ */

--- a/MDCcpp98/include/mdc/wchar_t/wide_decoding.hpp
+++ b/MDCcpp98/include/mdc/wchar_t/wide_decoding.hpp
@@ -1,0 +1,85 @@
+/**
+ * Mir Drualga Common For C++98
+ * Copyright (C) 2021  Mir Drualga
+ *
+ * This file is part of Mir Drualga Common For C++98.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any program (or a modified version of that program and its
+ *  libraries), containing parts covered by the terms of an incompatible
+ *  license, the licensors of this Program grant you additional permission
+ *  to convey the resulting work.
+ */
+
+#ifndef MDC_CPP98_WCHAR_T_WIDE_DECODING_HPP_
+#define MDC_CPP98_WCHAR_T_WIDE_DECODING_HPP_
+
+#include <stddef.h>
+
+#include <string>
+
+#include "../../../dllexport_define.inc"
+
+namespace mdc {
+namespace wide {
+
+DLLEXPORT ::std::wstring DecodeAscii(
+    const char* ascii_c_str
+);
+
+DLLEXPORT wchar_t* DecodeAscii(
+    wchar_t* wide_c_str,
+    const char* ascii_c_str
+);
+
+DLLEXPORT size_t DecodeAsciiLength(
+    const char* ascii_c_str
+);
+
+DLLEXPORT ::std::wstring DecodeDefaultMultibyte(
+    const char* multibyte_c_str
+);
+
+DLLEXPORT wchar_t* DecodeDefaultMultibyte(
+    wchar_t* wide_c_str,
+    const char* multibyte_c_str
+);
+
+DLLEXPORT size_t DecodeDefaultMultibyteLength(
+    const char* multibyte_c_str
+);
+
+DLLEXPORT ::std::wstring DecodeUtf8(
+    const char* utf8_c_str
+);
+
+DLLEXPORT wchar_t* DecodeUtf8(
+    wchar_t* wide_c_str,
+    const char* utf8_c_str
+);
+
+DLLEXPORT size_t DecodeUtf8Length(
+    const char* utf8_c_str
+);
+
+} // namespace wide
+} // namespace mdc
+
+#include "../../../dllexport_undefine.inc"
+#endif /* MDC_CPP98_WCHAR_T_WIDE_DECODING_HPP_ */

--- a/MDCcpp98/include/mdc/wchar_t/wide_encoding.hpp
+++ b/MDCcpp98/include/mdc/wchar_t/wide_encoding.hpp
@@ -1,0 +1,85 @@
+/**
+ * Mir Drualga Common For C++98
+ * Copyright (C) 2021  Mir Drualga
+ *
+ * This file is part of Mir Drualga Common For C++98.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any program (or a modified version of that program and its
+ *  libraries), containing parts covered by the terms of an incompatible
+ *  license, the licensors of this Program grant you additional permission
+ *  to convey the resulting work.
+ */
+
+#ifndef MDC_CPP98_WCHAR_T_WIDE_ENCODING_HPP_
+#define MDC_CPP98_WCHAR_T_WIDE_ENCODING_HPP_
+
+#include <stddef.h>
+
+#include <string>
+
+#include "../../../dllexport_define.inc"
+
+namespace mdc {
+namespace wide {
+
+DLLEXPORT ::std::string EncodeAscii(
+    const wchar_t* wide_c_str
+);
+
+DLLEXPORT char* EncodeAscii(
+    char* char_c_str,
+    const wchar_t* wide_c_str
+);
+
+DLLEXPORT size_t EncodeAsciiLength(
+    const wchar_t* wide_c_str
+);
+
+DLLEXPORT ::std::string EncodeDefaultMultibyte(
+    const wchar_t* wide_c_str
+);
+
+DLLEXPORT char* EncodeDefaultMultibyte(
+    char* char_c_str,
+    const wchar_t* wide_c_str
+);
+
+DLLEXPORT size_t EncodeDefaultMultibyteLength(
+    const wchar_t* wide_c_str
+);
+
+DLLEXPORT ::std::string EncodeUtf8(
+    const wchar_t* wide_c_str
+);
+
+DLLEXPORT char* EncodeUtf8(
+    char* char_c_str,
+    const wchar_t* wide_c_str
+);
+
+DLLEXPORT size_t EncodeUtf8Length(
+    const wchar_t* wide_c_str
+);
+
+} // namespace wide
+} // namespace mdc
+
+#include "../../../dllexport_undefine.inc"
+#endif /* MDC_CPP98_WCHAR_T_WIDE_ENCODING_HPP_ */

--- a/MDCcpp98/src/mdc/error/exit_on_error.cpp
+++ b/MDCcpp98/src/mdc/error/exit_on_error.cpp
@@ -27,75 +27,114 @@
  *  to convey the resulting work.
  */
 
-#ifndef MDC_CPP98_ERROR_EXIT_ON_ERROR_HPP_
-#define MDC_CPP98_ERROR_EXIT_ON_ERROR_HPP_
+#include "../../../include/mdc/error/exit_on_error.hpp"
 
-#if defined(_WIN32) || defined(_WIN64)
-  #include <windows.h>
-#endif /* defined(_WIN32) || defined(_WIN64) */
+#include <stdarg.h>
 
-#include <mdc/error/exit_on_error.h>
-
-#include "../../../dllexport_define.inc"
+#include <mdc/wchar_t/filew.h>
 
 namespace mdc {
 namespace error {
 
-enum {
-  kErrorMessageCapacity = Mdc_Error_kErrorMessageCapacity,
-};
-
-DLLEXPORT void ExitOnGeneralError(
+void ExitOnGeneralError(
     const wchar_t* caption_text,
     const wchar_t* message_format,
     const wchar_t* file_path_c_wstr,
     unsigned int line,
     ...
-);
+) {
+  va_list args;
 
-DLLEXPORT void ExitOnGeneralErrorV(
+  va_start(args, line);
+
+  Mdc_Error_ExitOnGeneralErrorV(
+      caption_text,
+      message_format,
+      file_path_c_wstr,
+      line,
+      args
+  );
+
+  va_end(args);
+}
+
+void ExitOnGeneralErrorV(
     const wchar_t* caption_text,
     const wchar_t* message_format,
     const wchar_t* file_path_c_wstr,
     unsigned int line,
     va_list args
-);
+) {
+  Mdc_Error_ExitOnGeneralErrorV(
+      caption_text,
+      message_format,
+      file_path_c_wstr,
+      line,
+      args
+  );
+}
 
-DLLEXPORT void ExitOnConstantMappingError(
+void ExitOnConstantMappingError(
     const wchar_t* file_path_c_wstr,
     unsigned int line,
     int value
-);
+) {
+  Mdc_Error_ExitOnConstantMappingError(
+      file_path_c_wstr,
+      line,
+      value
+  );
+}
 
-DLLEXPORT void ExitOnMemoryAllocError(
+void ExitOnMemoryAllocError(
     const wchar_t* file_path_c_wstr,
     unsigned int line
-);
+) {
+  Mdc_Error_ExitOnMemoryAllocError(
+      file_path_c_wstr,
+      line
+  );
+}
 
-DLLEXPORT void ExitOnMdcFunctionError(
+void ExitOnMdcFunctionError(
     const wchar_t* file_path_c_wstr,
     unsigned int line,
     const wchar_t* function_name
-);
+) {
+  Mdc_Error_ExitOnMdcFunctionError(
+      file_path_c_wstr,
+      line,
+      function_name
+  );
+}
 
-DLLEXPORT void ExitOnStaticInitError(
+void ExitOnStaticInitError(
     const wchar_t* file_path_c_wstr,
     unsigned int line
-);
+) {
+  Mdc_Error_ExitOnStaticInitError(
+      file_path_c_wstr,
+      line
+  );
+}
 
 #if defined(_WIN32) || defined(_WIN64)
 
-DLLEXPORT void ExitOnWindowsFunctionError(
+void ExitOnWindowsFunctionError(
     const wchar_t* file_path_c_wstr,
     unsigned int line,
     const wchar_t* function_name,
     DWORD last_error
-);
+) {
+  Mdc_Error_ExitOnWindowsFunctionError(
+      file_path_c_wstr,
+      line,
+      function_name,
+      last_error
+  );
+}
 
 #endif /* defined(_WIN32) || defined(_WIN64) */
 
 } // namespace error
 } // namespace mdc
-
-#include "../../../dllexport_undefine.inc"
-#endif /* MDC_CPP98_ERROR_EXIT_ON_ERROR_HPP_ */

--- a/MDCcpp98/src/mdc/std/condition_variable/condition_variable.cpp
+++ b/MDCcpp98/src/mdc/std/condition_variable/condition_variable.cpp
@@ -29,6 +29,8 @@
 
 #include "../../../../include/mdc/std/condition_variable.hpp"
 
+#if __cplusplus < 201103L && _MSVC_LANG < 201103L
+
 #include <stdexcept>
 
 namespace std {
@@ -61,3 +63,5 @@ void condition_variable::wait(unique_lock<mutex>& lock) {
 }
 
 } // namespace std
+
+#endif // __cplusplus < 201103L && _MSVC_LANG < 201103L

--- a/MDCcpp98/src/mdc/std/condition_variable/condition_variable.cpp
+++ b/MDCcpp98/src/mdc/std/condition_variable/condition_variable.cpp
@@ -58,8 +58,7 @@ void condition_variable::notify_all() throw() {
 }
 
 void condition_variable::wait(unique_lock<mutex>& lock) {
-  // TODO (Mir Drualga): Replace all of thread to implement this
-  // correctly.
+  ::cnd_wait(&this->condition_variable_, &lock.mutex()->native_handle());
 }
 
 } // namespace std

--- a/MDCcpp98/src/mdc/std/condition_variable/condition_variable.cpp
+++ b/MDCcpp98/src/mdc/std/condition_variable/condition_variable.cpp
@@ -1,0 +1,63 @@
+/**
+ * Mir Drualga Common For C++98
+ * Copyright (C) 2021  Mir Drualga
+ *
+ * This file is part of Mir Drualga Common For C++98.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any program (or a modified version of that program and its
+ *  libraries), containing parts covered by the terms of an incompatible
+ *  license, the licensors of this Program grant you additional permission
+ *  to convey the resulting work.
+ */
+
+#include "../../../../include/mdc/std/condition_variable.hpp"
+
+#include <stdexcept>
+
+namespace std {
+
+condition_variable::condition_variable() {
+  int init_result = ::cnd_init(&this->condition_variable_);
+
+  if (init_result != thrd_success) {
+    throw ::std::runtime_error(
+        "::std::condition_variable::condition_variable failure"
+    );
+  }
+}
+
+condition_variable::~condition_variable() {
+  ::cnd_destroy(&this->condition_variable_);
+}
+
+void condition_variable::notify_one() throw() {
+  ::cnd_signal(&this->condition_variable_);
+}
+
+void condition_variable::notify_all() throw() {
+  ::cnd_broadcast(&this->condition_variable_);
+}
+
+void condition_variable::wait(unique_lock<mutex>& lock) {
+  // TODO (Mir Drualga): Replace all of thread to implement this
+  // correctly.
+}
+
+} // namespace std

--- a/MDCcpp98/src/mdc/std/condition_variable/condition_variable_any.cpp
+++ b/MDCcpp98/src/mdc/std/condition_variable/condition_variable_any.cpp
@@ -1,0 +1,62 @@
+/**
+ * Mir Drualga Common For C++98
+ * Copyright (C) 2021  Mir Drualga
+ *
+ * This file is part of Mir Drualga Common For C++98.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any program (or a modified version of that program and its
+ *  libraries), containing parts covered by the terms of an incompatible
+ *  license, the licensors of this Program grant you additional permission
+ *  to convey the resulting work.
+ */
+
+#include "../../../../include/mdc/std/condition_variable.hpp"
+
+#if __cplusplus < 201103L && _MSVC_LANG < 201103L
+
+#include <stdexcept>
+
+namespace std {
+
+condition_variable_any::condition_variable_any() {
+  int init_result = ::cnd_init(&this->condition_variable_);
+
+  if (init_result != thrd_success) {
+    throw ::std::runtime_error(
+        "::std::condition_variable_any::condition_variable_any failure"
+    );
+  }
+}
+
+condition_variable_any::~condition_variable_any() {
+  ::cnd_destroy(&this->condition_variable_);
+}
+
+void condition_variable_any::notify_one() throw() {
+  ::cnd_signal(&this->condition_variable_);
+}
+
+void condition_variable_any::notify_all() throw() {
+  ::cnd_broadcast(&this->condition_variable_);
+}
+
+} // namespace std
+
+#endif // __cplusplus < 201103L && _MSVC_LANG < 201103L

--- a/MDCcpp98/src/mdc/std/mutex/call_once.cpp
+++ b/MDCcpp98/src/mdc/std/mutex/call_once.cpp
@@ -1,0 +1,50 @@
+/**
+ * Mir Drualga Common For C++98
+ * Copyright (C) 2021  Mir Drualga
+ *
+ * This file is part of Mir Drualga Common For C++98.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any program (or a modified version of that program and its
+ *  libraries), containing parts covered by the terms of an incompatible
+ *  license, the licensors of this Program grant you additional permission
+ *  to convey the resulting work.
+ */
+
+#include "../../../../include/mdc/std/mutex.hpp"
+
+#include <stdexcept>
+
+#if __cplusplus < 201103L && _MSVC_LANG < 201103L
+
+namespace std {
+
+const ::once_flag once_flag::kDefaultInit = ONCE_FLAG_INIT;
+
+once_flag::once_flag() throw()
+    : once_flag_(kDefaultInit) {
+}
+
+void call_once(once_flag& flag, void (*func)(void)) {
+  ::call_once(&flag.once_flag_, func);
+}
+
+} // namespace std
+
+#endif // __cplusplus < 201103L && _MSVC_LANG < 201103L

--- a/MDCcpp98/src/mdc/std/mutex/mutex.cpp
+++ b/MDCcpp98/src/mdc/std/mutex/mutex.cpp
@@ -59,6 +59,10 @@ void mutex::unlock() {
   ::mtx_unlock(&this->mutex_);
 }
 
+mutex::native_handle_type mutex::native_handle() {
+  return this->mutex_;
+}
+
 } // namespace std
 
 #endif // __cplusplus < 201103L && _MSVC_LANG < 201103L

--- a/MDCcpp98/src/mdc/std/mutex/mutex.cpp
+++ b/MDCcpp98/src/mdc/std/mutex/mutex.cpp
@@ -1,0 +1,64 @@
+/**
+ * Mir Drualga Common For C++98
+ * Copyright (C) 2021  Mir Drualga
+ *
+ * This file is part of Mir Drualga Common For C++98.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any program (or a modified version of that program and its
+ *  libraries), containing parts covered by the terms of an incompatible
+ *  license, the licensors of this Program grant you additional permission
+ *  to convey the resulting work.
+ */
+
+#include "../../../../include/mdc/std/mutex.hpp"
+
+#include <stdexcept>
+
+#if __cplusplus < 201103L && _MSVC_LANG < 201103L
+
+namespace std {
+
+mutex::mutex() {
+  ::mtx_init(&this->mutex_, mtx_plain);
+}
+
+mutex::~mutex() {
+  ::mtx_destroy(&this->mutex_);
+}
+
+void mutex::lock() {
+  int lock_result = ::mtx_lock(&this->mutex_);
+
+  if (lock_result != thrd_success) {
+    throw ::std::runtime_error("::std::mutex::lock failure");
+  }
+}
+
+bool mutex::try_lock() {
+  return !!::mtx_trylock(&this->mutex_);
+}
+
+void mutex::unlock() {
+  ::mtx_unlock(&this->mutex_);
+}
+
+} // namespace std
+
+#endif // __cplusplus < 201103L && _MSVC_LANG < 201103L

--- a/MDCcpp98/src/mdc/std/mutex/recursive_mutex.cpp
+++ b/MDCcpp98/src/mdc/std/mutex/recursive_mutex.cpp
@@ -1,0 +1,64 @@
+/**
+ * Mir Drualga Common For C++98
+ * Copyright (C) 2021  Mir Drualga
+ *
+ * This file is part of Mir Drualga Common For C++98.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any program (or a modified version of that program and its
+ *  libraries), containing parts covered by the terms of an incompatible
+ *  license, the licensors of this Program grant you additional permission
+ *  to convey the resulting work.
+ */
+
+#include "../../../../include/mdc/std/mutex.hpp"
+
+#include <stdexcept>
+
+#if __cplusplus < 201103L && _MSVC_LANG < 201103L
+
+namespace std {
+
+recursive_mutex::recursive_mutex() {
+  ::mtx_init(&this->mutex_, mtx_plain | mtx_recursive);
+}
+
+recursive_mutex::~recursive_mutex() {
+  ::mtx_destroy(&this->mutex_);
+}
+
+void recursive_mutex::lock() {
+  int lock_result = ::mtx_lock(&this->mutex_);
+
+  if (lock_result != thrd_success) {
+    throw ::std::runtime_error("::std::mutex::lock failure");
+  }
+}
+
+bool recursive_mutex::try_lock() {
+  return !!::mtx_trylock(&this->mutex_);
+}
+
+void recursive_mutex::unlock() {
+  ::mtx_unlock(&this->mutex_);
+}
+
+} // namespace std
+
+#endif // __cplusplus < 201103L && _MSVC_LANG < 201103L

--- a/MDCcpp98/src/mdc/std/mutex/recursive_mutex.cpp
+++ b/MDCcpp98/src/mdc/std/mutex/recursive_mutex.cpp
@@ -59,6 +59,10 @@ void recursive_mutex::unlock() {
   ::mtx_unlock(&this->mutex_);
 }
 
+recursive_mutex::native_handle_type recursive_mutex::native_handle() {
+  return this->mutex_;
+}
+
 } // namespace std
 
 #endif // __cplusplus < 201103L && _MSVC_LANG < 201103L

--- a/MDCcpp98/src/mdc/std/threads.cpp
+++ b/MDCcpp98/src/mdc/std/threads.cpp
@@ -1,0 +1,72 @@
+/**
+ * Mir Drualga Common For C++98
+ * Copyright (C) 2021  Mir Drualga
+ *
+ * This file is part of Mir Drualga Common For C++98.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any program (or a modified version of that program and its
+ *  libraries), containing parts covered by the terms of an incompatible
+ *  license, the licensors of this Program grant you additional permission
+ *  to convey the resulting work.
+ */
+
+#include "../../../include/mdc/std/threads.hpp"
+
+#include <stdexcept>
+
+#if __cplusplus < 201103L && _MSVC_LANG < 201103L
+
+namespace std {
+
+/**
+ * thread
+ */
+
+thread::thread(int (*func)(void*), void* arg) {
+  int create_result = thrd_create(&this->thread_, func, arg);
+
+  if (create_result != thrd_success) {
+    throw ::std::runtime_error("::std::thread::thread failure");
+  }
+}
+
+void thread::join() {
+  int result_code;
+
+  int join_result = thrd_join(this->thread_, &result_code);
+
+  if (join_result != thrd_success) {
+    throw ::std::runtime_error("::std::thread::join failure");
+  }
+}
+
+void thread::detach() {
+  int detach_result = thrd_detach(this->thread_);
+}
+
+void thread::swap(thread& other) {
+  thrd_t temp = this->thread_;
+  this->thread_ = other.thread_;
+  other.thread_ = temp;
+}
+
+} // namespace std
+
+#endif // __cplusplus < 201103L && _MSVC_LANG < 201103L

--- a/MDCcpp98/src/mdc/std/threads/threads.cpp
+++ b/MDCcpp98/src/mdc/std/threads/threads.cpp
@@ -27,7 +27,7 @@
  *  to convey the resulting work.
  */
 
-#include "../../../include/mdc/std/threads.hpp"
+#include "../../../../include/mdc/std/threads.hpp"
 
 #include <stdexcept>
 

--- a/MDCcpp98/src/mdc/wchar_t/wide_decoding.cpp
+++ b/MDCcpp98/src/mdc/wchar_t/wide_decoding.cpp
@@ -1,0 +1,124 @@
+/**
+ * Mir Drualga Common For C++98
+ * Copyright (C) 2021  Mir Drualga
+ *
+ * This file is part of Mir Drualga Common For C++98.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any program (or a modified version of that program and its
+ *  libraries), containing parts covered by the terms of an incompatible
+ *  license, the licensors of this Program grant you additional permission
+ *  to convey the resulting work.
+ */
+
+#include "../../../include/mdc/wchar_t/wide_decoding.hpp"
+
+#include <mdc/wchar_t/wide_decoding.h>
+
+namespace mdc {
+namespace wide {
+namespace {
+
+static ::std::wstring DecodeChar(
+    const char* char_c_str,
+    wchar_t* (*decode_func)(wchar_t*, const char*),
+    size_t (*length_func)(const char*)
+) {
+  size_t wide_c_str_length = length_func(char_c_str);
+
+  ::std::wstring wide_str(wide_c_str_length, '\0');
+
+  decode_func(&wide_str[0], char_c_str);
+
+  return wide_str;
+}
+
+} // namespace
+
+::std::wstring DecodeAscii(
+    const char* ascii_c_str
+) {
+  return DecodeChar(
+      ascii_c_str,
+      &DecodeAscii,
+      &DecodeAsciiLength
+  );
+}
+
+wchar_t* DecodeAscii(
+    wchar_t* wide_c_str,
+    const char* ascii_c_str
+) {
+  return Mdc_Wide_DecodeAscii(wide_c_str, ascii_c_str);
+}
+
+size_t DecodeAsciiLength(
+    const char* ascii_c_str
+) {
+  return Mdc_Wide_DecodeAsciiLength(ascii_c_str);
+}
+
+::std::wstring DecodeDefaultMultibyte(
+    const char* multibyte_c_str
+) {
+  return DecodeChar(
+      multibyte_c_str,
+      &DecodeDefaultMultibyte,
+      &DecodeDefaultMultibyteLength
+  );
+}
+
+wchar_t* DecodeDefaultMultibyte(
+    wchar_t* wide_c_str,
+    const char* multibyte_c_str
+) {
+  return Mdc_Wide_DecodeDefaultMultibyte(wide_c_str, multibyte_c_str);
+}
+
+size_t DecodeDefaultMultibyteLength(
+    const char* multibyte_c_str
+) {
+  return Mdc_Wide_DecodeDefaultMultibyteLength(multibyte_c_str);
+}
+
+::std::wstring DecodeUtf8(
+    const char* utf8_c_str
+) {
+  return DecodeChar(
+      utf8_c_str,
+      &DecodeUtf8,
+      &DecodeUtf8Length
+  );
+}
+
+wchar_t* DecodeUtf8(
+    wchar_t* wide_c_str,
+    const char* utf8_c_str
+) {
+  return Mdc_Wide_DecodeUtf8(wide_c_str, utf8_c_str);
+}
+
+size_t DecodeUtf8Length(
+    const char* utf8_c_str
+) {
+  return Mdc_Wide_DecodeUtf8Length(utf8_c_str);
+}
+
+} // namespace wide
+} // namespace mdc

--- a/MDCcpp98/src/mdc/wchar_t/wide_encoding.cpp
+++ b/MDCcpp98/src/mdc/wchar_t/wide_encoding.cpp
@@ -1,0 +1,124 @@
+/**
+ * Mir Drualga Common For C++98
+ * Copyright (C) 2021  Mir Drualga
+ *
+ * This file is part of Mir Drualga Common For C++98.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any program (or a modified version of that program and its
+ *  libraries), containing parts covered by the terms of an incompatible
+ *  license, the licensors of this Program grant you additional permission
+ *  to convey the resulting work.
+ */
+
+#include "../../../include/mdc/wchar_t/wide_encoding.hpp"
+
+#include <mdc/wchar_t/wide_encoding.h>
+
+namespace mdc {
+namespace wide {
+namespace {
+
+static ::std::string EncodeChar(
+    const wchar_t* wide_c_str,
+    char* (*encode_func)(char*, const wchar_t*),
+    size_t (*length_func)(const wchar_t*)
+) {
+  size_t char_c_str_length = length_func(wide_c_str);
+
+  ::std::string char_str(char_c_str_length, '\0');
+
+  encode_func(&char_str[0], wide_c_str);
+
+  return char_str;
+}
+
+} // namespace
+
+::std::string EncodeAscii(
+    const wchar_t* wide_c_str
+) {
+  return EncodeChar(
+      wide_c_str,
+      &EncodeAscii,
+      &EncodeAsciiLength
+  );
+}
+
+char* EncodeAscii(
+    char* char_c_str,
+    const wchar_t* wide_c_str
+) {
+  return Mdc_Wide_EncodeAscii(char_c_str, wide_c_str);
+}
+
+size_t EncodeAsciiLength(
+    const wchar_t* wide_c_str
+) {
+  return Mdc_Wide_EncodeAsciiLength(wide_c_str);
+}
+
+::std::string EncodeDefaultMultibyte(
+    const wchar_t* wide_c_str
+) {
+  return EncodeChar(
+      wide_c_str,
+      &EncodeDefaultMultibyte,
+      &EncodeDefaultMultibyteLength
+  );
+}
+
+char* EncodeDefaultMultibyte(
+    char* char_c_str,
+    const wchar_t* wide_c_str
+) {
+  return Mdc_Wide_EncodeDefaultMultibyte(char_c_str, wide_c_str);
+}
+
+size_t EncodeDefaultMultibyteLength(
+    const wchar_t* wide_c_str
+) {
+  return Mdc_Wide_EncodeDefaultMultibyteLength(wide_c_str);
+}
+
+::std::string EncodeUtf8(
+    const wchar_t* wide_c_str
+) {
+  return EncodeChar(
+      wide_c_str,
+      &EncodeUtf8,
+      &EncodeUtf8Length
+  );
+}
+
+char* EncodeUtf8(
+    char* char_c_str,
+    const wchar_t* wide_c_str
+) {
+  return Mdc_Wide_EncodeUtf8(char_c_str, wide_c_str);
+}
+
+size_t EncodeUtf8Length(
+    const wchar_t* wide_c_str
+) {
+  return Mdc_Wide_EncodeUtf8Length(wide_c_str);
+}
+
+} // namespace wide
+} // namespace mdc

--- a/Tests/COPYING
+++ b/Tests/COPYING
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<http://www.gnu.org/licenses/>.

--- a/Tests/LICENSE.md
+++ b/Tests/LICENSE.md
@@ -22,28 +22,3 @@ it with any program (or a modified version of that program and its
 libraries), containing parts covered by the terms of an incompatible
 license, the licensors of this Program grant you additional permission
 to convey the resulting work.
-
-# Mir Drualga Common For C++98
-Copyright (C) 2021  Mir Drualga
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU Affero General Public License as published
-by the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Affero General Public License for more details.
-
-You should have received a copy of the GNU Affero General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-Additional permissions under GNU Affero General Public License version 3
-section 7
-
-If you modify this Program, or any covered work, by linking or combining
-it with any program (or a modified version of that program and its
-libraries), containing parts covered by the terms of an incompatible
-license, the licensors of this Program grant you additional permission
-to convey the resulting work.

--- a/Tests/Tests.dsp
+++ b/Tests/Tests.dsp
@@ -142,16 +142,16 @@ SOURCE=.\tests\mdc\std\threads_tests.h
 # Begin Group "wchar_t"
 
 # PROP Default_Filter ""
-# Begin Group "example_text"
+# Begin Group "wide_example_text"
 
 # PROP Default_Filter ""
 # Begin Source File
 
-SOURCE=.\tests\mdc\wchar_t\example_text\example_text.c
+SOURCE=.\tests\mdc\wchar_t\wide_example_text\wide_example_text.c
 # End Source File
 # Begin Source File
 
-SOURCE=.\tests\mdc\wchar_t\example_text\example_text.h
+SOURCE=.\tests\mdc\wchar_t\wide_example_text\wide_example_text.h
 # End Source File
 # End Group
 # Begin Source File

--- a/Tests/tests/mdc/error/exit_on_error_tests.c
+++ b/Tests/tests/mdc/error/exit_on_error_tests.c
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/Tests/tests/mdc/error/exit_on_error_tests.h
+++ b/Tests/tests/mdc/error/exit_on_error_tests.h
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/Tests/tests/mdc/error_tests.c
+++ b/Tests/tests/mdc/error_tests.c
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/Tests/tests/mdc/error_tests.h
+++ b/Tests/tests/mdc/error_tests.h
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/Tests/tests/mdc/main.c
+++ b/Tests/tests/mdc/main.c
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/Tests/tests/mdc/std/assert_tests.c
+++ b/Tests/tests/mdc/std/assert_tests.c
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/Tests/tests/mdc/std/assert_tests.h
+++ b/Tests/tests/mdc/std/assert_tests.h
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/Tests/tests/mdc/std/stdbool_tests.c
+++ b/Tests/tests/mdc/std/stdbool_tests.c
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/Tests/tests/mdc/std/stdbool_tests.h
+++ b/Tests/tests/mdc/std/stdbool_tests.h
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/Tests/tests/mdc/std/stdint_tests.c
+++ b/Tests/tests/mdc/std/stdint_tests.c
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/Tests/tests/mdc/std/stdint_tests.h
+++ b/Tests/tests/mdc/std/stdint_tests.h
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/Tests/tests/mdc/std/threads_tests.c
+++ b/Tests/tests/mdc/std/threads_tests.c
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/Tests/tests/mdc/std/threads_tests.h
+++ b/Tests/tests/mdc/std/threads_tests.h
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/Tests/tests/mdc/std_tests.c
+++ b/Tests/tests/mdc/std_tests.c
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/Tests/tests/mdc/std_tests.h
+++ b/Tests/tests/mdc/std_tests.h
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/Tests/tests/mdc/wchar_t/filew_tests.c
+++ b/Tests/tests/mdc/wchar_t/filew_tests.c
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/Tests/tests/mdc/wchar_t/filew_tests.h
+++ b/Tests/tests/mdc/wchar_t/filew_tests.h
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/Tests/tests/mdc/wchar_t/wide_decoding_tests.c
+++ b/Tests/tests/mdc/wchar_t/wide_decoding_tests.c
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/Tests/tests/mdc/wchar_t/wide_decoding_tests.c
+++ b/Tests/tests/mdc/wchar_t/wide_decoding_tests.c
@@ -36,7 +36,7 @@
 #include <mdc/malloc/malloc.h>
 #include <mdc/std/wchar.h>
 #include <mdc/wchar_t/wide_decoding.h>
-#include "example_text/example_text.h"
+#include "wide_example_text/wide_example_text.h"
 
 static void Mdc_WideDecoding_AssertDecodeAscii(void) {
   wchar_t* wide_c_str;

--- a/Tests/tests/mdc/wchar_t/wide_decoding_tests.h
+++ b/Tests/tests/mdc/wchar_t/wide_decoding_tests.h
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/Tests/tests/mdc/wchar_t/wide_encoding_tests.c
+++ b/Tests/tests/mdc/wchar_t/wide_encoding_tests.c
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/Tests/tests/mdc/wchar_t/wide_encoding_tests.c
+++ b/Tests/tests/mdc/wchar_t/wide_encoding_tests.c
@@ -36,7 +36,7 @@
 #include <mdc/malloc/malloc.h>
 #include <mdc/std/wchar.h>
 #include <mdc/wchar_t/wide_encoding.h>
-#include "example_text/example_text.h"
+#include "wide_example_text/wide_example_text.h"
 
 static void Mdc_WideEncoding_AssertEncodeAscii(void) {
   char* ascii_c_str;

--- a/Tests/tests/mdc/wchar_t/wide_encoding_tests.h
+++ b/Tests/tests/mdc/wchar_t/wide_encoding_tests.h
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/Tests/tests/mdc/wchar_t/wide_example_text/wide_example_text.c
+++ b/Tests/tests/mdc/wchar_t/wide_example_text/wide_example_text.c
@@ -27,14 +27,14 @@
  *  to convey the resulting work.
  */
 
-#ifndef MDC_TESTS_C_WCHAR_T_EXAMPLE_TEXT_EXAMPLE_TEXT_H_
-#define MDC_TESTS_C_WCHAR_T_EXAMPLE_TEXT_EXAMPLE_TEXT_H_
+#include "wide_example_text.h"
 
-#include <mdc/std/wchar.h>
+const char* const kAsciiExampleText =
+    "The quick brown fox jumped over the lazy dog.";
 
-extern const char* const kAsciiExampleText;
-extern const wchar_t* const kAsciiExampleTextWide;
-extern const char* const kUtf8ExampleText;
-extern const wchar_t* const kUtf8ExampleTextWide;
+const wchar_t* const kAsciiExampleTextWide =
+    L"The quick brown fox jumped over the lazy dog.";
 
-#endif /* MDC_TESTS_C_WCHAR_T_EXAMPLE_TEXT_EXAMPLE_TEXT_H_ */
+const char* const kUtf8ExampleText = "\xc3\xbf";
+
+const wchar_t* const kUtf8ExampleTextWide = L"\xff";

--- a/Tests/tests/mdc/wchar_t/wide_example_text/wide_example_text.c
+++ b/Tests/tests/mdc/wchar_t/wide_example_text/wide_example_text.c
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/Tests/tests/mdc/wchar_t/wide_example_text/wide_example_text.h
+++ b/Tests/tests/mdc/wchar_t/wide_example_text/wide_example_text.h
@@ -27,14 +27,14 @@
  *  to convey the resulting work.
  */
 
-#include "example_text.h"
+#ifndef MDC_TESTS_C_WCHAR_T_WIDE_EXAMPLE_TEXT_WIDE_EXAMPLE_TEXT_H_
+#define MDC_TESTS_C_WCHAR_T_WIDE_EXAMPLE_TEXT_WIDE_EXAMPLE_TEXT_H_
 
-const char* const kAsciiExampleText =
-    "The quick brown fox jumped over the lazy dog.";
+#include <mdc/std/wchar.h>
 
-const wchar_t* const kAsciiExampleTextWide =
-    L"The quick brown fox jumped over the lazy dog.";
+extern const char* const kAsciiExampleText;
+extern const wchar_t* const kAsciiExampleTextWide;
+extern const char* const kUtf8ExampleText;
+extern const wchar_t* const kUtf8ExampleTextWide;
 
-const char* const kUtf8ExampleText = "\xc3\xbf";
-
-const wchar_t* const kUtf8ExampleTextWide = L"\xff";
+#endif /* MDC_TESTS_C_WCHAR_T_WIDE_EXAMPLE_TEXT_WIDE_EXAMPLE_TEXT_H_ */

--- a/Tests/tests/mdc/wchar_t/wide_example_text/wide_example_text.h
+++ b/Tests/tests/mdc/wchar_t/wide_example_text/wide_example_text.h
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/Tests/tests/mdc/wchar_t_tests.c
+++ b/Tests/tests/mdc/wchar_t_tests.c
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/Tests/tests/mdc/wchar_t_tests.h
+++ b/Tests/tests/mdc/wchar_t_tests.h
@@ -1,6 +1,6 @@
 /**
  * Mir Drualga Common For C
- * Copyright (C) 2020  Mir Drualga
+ * Copyright (C) 2020-2021  Mir Drualga
  *
  * This file is part of Mir Drualga Common For C.
  *

--- a/TestsCpp98/COPYING
+++ b/TestsCpp98/COPYING
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<http://www.gnu.org/licenses/>.

--- a/TestsCpp98/LICENSE.md
+++ b/TestsCpp98/LICENSE.md
@@ -1,0 +1,24 @@
+# Mir Drualga Common For C++98
+Copyright (C) 2021  Mir Drualga
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Additional permissions under GNU Affero General Public License version 3
+section 7
+
+If you modify this Program, or any covered work, by linking or combining
+it with any program (or a modified version of that program and its
+libraries), containing parts covered by the terms of an incompatible
+license, the licensors of this Program grant you additional permission
+to convey the resulting work.

--- a/TestsCpp98/TestsCpp98.dsp
+++ b/TestsCpp98/TestsCpp98.dsp
@@ -1,0 +1,146 @@
+# Microsoft Developer Studio Project File - Name="TestsCpp98" - Package Owner=<4>
+# Microsoft Developer Studio Generated Build File, Format Version 6.00
+# ** DO NOT EDIT **
+
+# TARGTYPE "Win32 (x86) Console Application" 0x0103
+
+CFG=TestsCpp98 - Win32 Debug
+!MESSAGE This is not a valid makefile. To build this project using NMAKE,
+!MESSAGE use the Export Makefile command and run
+!MESSAGE 
+!MESSAGE NMAKE /f "TestsCpp98.mak".
+!MESSAGE 
+!MESSAGE You can specify a configuration when running NMAKE
+!MESSAGE by defining the macro CFG on the command line. For example:
+!MESSAGE 
+!MESSAGE NMAKE /f "TestsCpp98.mak" CFG="TestsCpp98 - Win32 Debug"
+!MESSAGE 
+!MESSAGE Possible choices for configuration are:
+!MESSAGE 
+!MESSAGE "TestsCpp98 - Win32 Release" (based on "Win32 (x86) Console Application")
+!MESSAGE "TestsCpp98 - Win32 Debug" (based on "Win32 (x86) Console Application")
+!MESSAGE 
+
+# Begin Project
+# PROP AllowPerConfigDependencies 0
+# PROP Scc_ProjName ""
+# PROP Scc_LocalPath ""
+CPP=cl.exe
+RSC=rc.exe
+
+!IF  "$(CFG)" == "TestsCpp98 - Win32 Release"
+
+# PROP BASE Use_MFC 0
+# PROP BASE Use_Debug_Libraries 0
+# PROP BASE Output_Dir "Release"
+# PROP BASE Intermediate_Dir "Release"
+# PROP BASE Target_Dir ""
+# PROP Use_MFC 0
+# PROP Use_Debug_Libraries 0
+# PROP Output_Dir "Release"
+# PROP Intermediate_Dir "Release"
+# PROP Ignore_Export_Lib 0
+# PROP Target_Dir ""
+# ADD BASE CPP /nologo /W3 /GX /O2 /D "WIN32" /D "NDEBUG" /D "_CONSOLE" /D "_MBCS" /YX /FD /c
+# ADD CPP /nologo /MD /W3 /GX /O2 /D "WIN32" /D "NDEBUG" /D "_CONSOLE" /D "_UNICODE" /D "UNICODE" /YX /FD /c
+# ADD BASE RSC /l 0x409 /d "NDEBUG"
+# ADD RSC /l 0x409 /d "NDEBUG"
+BSC32=bscmake.exe
+# ADD BASE BSC32 /nologo
+# ADD BSC32 /nologo
+LINK32=link.exe
+# ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /machine:I386
+# ADD LINK32 libunicows.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /machine:I386
+
+!ELSEIF  "$(CFG)" == "TestsCpp98 - Win32 Debug"
+
+# PROP BASE Use_MFC 0
+# PROP BASE Use_Debug_Libraries 1
+# PROP BASE Output_Dir "Debug"
+# PROP BASE Intermediate_Dir "Debug"
+# PROP BASE Target_Dir ""
+# PROP Use_MFC 0
+# PROP Use_Debug_Libraries 1
+# PROP Output_Dir "Debug"
+# PROP Intermediate_Dir "Debug"
+# PROP Ignore_Export_Lib 0
+# PROP Target_Dir ""
+# ADD BASE CPP /nologo /W3 /Gm /GX /ZI /Od /D "WIN32" /D "_DEBUG" /D "_CONSOLE" /D "_MBCS" /YX /FD /GZ /c
+# ADD CPP /nologo /MDd /W3 /Gm /GX /ZI /Od /D "WIN32" /D "_DEBUG" /D "_CONSOLE" /D "_UNICODE" /D "UNICODE" /YX /FD /GZ /c
+# ADD BASE RSC /l 0x409 /d "_DEBUG"
+# ADD RSC /l 0x409 /d "_DEBUG"
+BSC32=bscmake.exe
+# ADD BASE BSC32 /nologo
+# ADD BSC32 /nologo
+LINK32=link.exe
+# ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /debug /machine:I386 /pdbtype:sept
+# ADD LINK32 libunicows.lib MDCcD.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /debug /machine:I386 /pdbtype:sept
+
+!ENDIF 
+
+# Begin Target
+
+# Name "TestsCpp98 - Win32 Release"
+# Name "TestsCpp98 - Win32 Debug"
+# Begin Group "Files"
+
+# PROP Default_Filter ""
+# Begin Group "tests"
+
+# PROP Default_Filter ""
+# Begin Group "mdc"
+
+# PROP Default_Filter ""
+# Begin Group "error"
+
+# PROP Default_Filter ""
+# Begin Source File
+
+SOURCE=.\test\mdc\error\exit_on_error_tests.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\test\mdc\error\exit_on_error_tests.hpp
+# End Source File
+# End Group
+# Begin Group "std"
+
+# PROP Default_Filter ""
+# End Group
+# Begin Group "wchar_t"
+
+# PROP Default_Filter ""
+# End Group
+# Begin Source File
+
+SOURCE=.\test\mdc\error_tests.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\test\mdc\error_tests.hpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\test\mdc\main.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\test\mdc\std_tests.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\test\mdc\std_tests.hpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\test\mdc\wchar_t_tests.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\test\mdc\wchar_t_tests.hpp
+# End Source File
+# End Group
+# End Group
+# End Group
+# End Target
+# End Project

--- a/TestsCpp98/TestsCpp98.dsp
+++ b/TestsCpp98/TestsCpp98.dsp
@@ -50,7 +50,7 @@ BSC32=bscmake.exe
 # ADD BSC32 /nologo
 LINK32=link.exe
 # ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /machine:I386
-# ADD LINK32 libunicows.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /machine:I386
+# ADD LINK32 libunicows.lib MDCc.lib MDCcpp98.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /machine:I386
 
 !ELSEIF  "$(CFG)" == "TestsCpp98 - Win32 Debug"
 
@@ -74,7 +74,7 @@ BSC32=bscmake.exe
 # ADD BSC32 /nologo
 LINK32=link.exe
 # ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /debug /machine:I386 /pdbtype:sept
-# ADD LINK32 libunicows.lib MDCcD.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /debug /machine:I386 /pdbtype:sept
+# ADD LINK32 libunicows.lib MDCcD.lib MDCcpp98.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /debug /machine:I386 /pdbtype:sept
 
 !ENDIF 
 

--- a/TestsCpp98/TestsCpp98.dsp
+++ b/TestsCpp98/TestsCpp98.dsp
@@ -110,6 +110,34 @@ SOURCE=.\test\mdc\error\exit_on_error_tests.hpp
 # Begin Group "wchar_t"
 
 # PROP Default_Filter ""
+# Begin Group "example_text"
+
+# PROP Default_Filter ""
+# Begin Source File
+
+SOURCE=.\test\mdc\wchar_t\example_text\example_text.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\test\mdc\wchar_t\example_text\example_text.hpp
+# End Source File
+# End Group
+# Begin Source File
+
+SOURCE=.\test\mdc\wchar_t\wide_decoding_tests.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\test\mdc\wchar_t\wide_decoding_tests.hpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\test\mdc\wchar_t\wide_encoding_tests.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\test\mdc\wchar_t\wide_encoding_tests.hpp
+# End Source File
 # End Group
 # Begin Source File
 

--- a/TestsCpp98/TestsCpp98.dsp
+++ b/TestsCpp98/TestsCpp98.dsp
@@ -120,11 +120,19 @@ SOURCE=.\test\mdc\std\std_example_funcs\std_increment.hpp
 # End Group
 # Begin Source File
 
-SOURCE=.\test\mdc\std\threads_tests.cpp
+SOURCE=.\test\mdc\std\mutex_tests.cpp
 # End Source File
 # Begin Source File
 
-SOURCE=.\test\mdc\std\threads_tests.hpp
+SOURCE=.\test\mdc\std\mutex_tests.hpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\test\mdc\std\thread_tests.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\test\mdc\std\thread_tests.hpp
 # End Source File
 # End Group
 # Begin Group "wchar_t"

--- a/TestsCpp98/TestsCpp98.dsp
+++ b/TestsCpp98/TestsCpp98.dsp
@@ -106,6 +106,18 @@ SOURCE=.\test\mdc\error\exit_on_error_tests.hpp
 # Begin Group "std"
 
 # PROP Default_Filter ""
+# Begin Group "std_example_funcs"
+
+# PROP Default_Filter ""
+# Begin Source File
+
+SOURCE=.\test\mdc\std\std_example_funcs\std_increment.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\test\mdc\std\std_example_funcs\std_increment.hpp
+# End Source File
+# End Group
 # Begin Source File
 
 SOURCE=.\test\mdc\std\threads_tests.cpp

--- a/TestsCpp98/TestsCpp98.dsp
+++ b/TestsCpp98/TestsCpp98.dsp
@@ -74,7 +74,7 @@ BSC32=bscmake.exe
 # ADD BSC32 /nologo
 LINK32=link.exe
 # ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /debug /machine:I386 /pdbtype:sept
-# ADD LINK32 libunicows.lib MDCcD.lib MDCcpp98.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /debug /machine:I386 /pdbtype:sept
+# ADD LINK32 libunicows.lib MDCcD.lib MDCcpp98D.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /debug /machine:I386 /pdbtype:sept
 
 !ENDIF 
 

--- a/TestsCpp98/TestsCpp98.dsp
+++ b/TestsCpp98/TestsCpp98.dsp
@@ -128,6 +128,14 @@ SOURCE=.\test\mdc\std\mutex_tests.hpp
 # End Source File
 # Begin Source File
 
+SOURCE=.\test\mdc\std\recursive_mutex_tests.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\test\mdc\std\recursive_mutex_tests.hpp
+# End Source File
+# Begin Source File
+
 SOURCE=.\test\mdc\std\thread_tests.cpp
 # End Source File
 # Begin Source File

--- a/TestsCpp98/TestsCpp98.dsp
+++ b/TestsCpp98/TestsCpp98.dsp
@@ -118,16 +118,16 @@ SOURCE=.\test\mdc\std\threads_tests.hpp
 # Begin Group "wchar_t"
 
 # PROP Default_Filter ""
-# Begin Group "example_text"
+# Begin Group "wide_example_text"
 
 # PROP Default_Filter ""
 # Begin Source File
 
-SOURCE=.\test\mdc\wchar_t\example_text\example_text.cpp
+SOURCE=.\test\mdc\wchar_t\wide_example_text\wide_example_text.cpp
 # End Source File
 # Begin Source File
 
-SOURCE=.\test\mdc\wchar_t\example_text\example_text.hpp
+SOURCE=.\test\mdc\wchar_t\wide_example_text\wide_example_text.hpp
 # End Source File
 # End Group
 # Begin Source File

--- a/TestsCpp98/TestsCpp98.dsp
+++ b/TestsCpp98/TestsCpp98.dsp
@@ -128,6 +128,14 @@ SOURCE=.\test\mdc\std\mutex_tests.hpp
 # End Source File
 # Begin Source File
 
+SOURCE=.\test\mdc\std\once_flag_tests.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\test\mdc\std\once_flag_tests.hpp
+# End Source File
+# Begin Source File
+
 SOURCE=.\test\mdc\std\recursive_mutex_tests.cpp
 # End Source File
 # Begin Source File

--- a/TestsCpp98/TestsCpp98.dsp
+++ b/TestsCpp98/TestsCpp98.dsp
@@ -106,6 +106,14 @@ SOURCE=.\test\mdc\error\exit_on_error_tests.hpp
 # Begin Group "std"
 
 # PROP Default_Filter ""
+# Begin Source File
+
+SOURCE=.\test\mdc\std\threads_tests.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\test\mdc\std\threads_tests.hpp
+# End Source File
 # End Group
 # Begin Group "wchar_t"
 

--- a/TestsCpp98/test/mdc/error/exit_on_error_tests.cpp
+++ b/TestsCpp98/test/mdc/error/exit_on_error_tests.cpp
@@ -31,7 +31,8 @@
 
 #include <mdc/error/exit_on_error.hpp>
 
-namespace mdc {
+namespace mdc_test {
+namespace error_test {
 namespace {
 
 static void AssertExitOnGeneralError() {
@@ -98,4 +99,5 @@ void ExitOnError_RunTests() {
 #endif /* defined(_WIN32) || defined(_WIN64) */
 }
 
-} // namespace mdc
+} // namespace error_test
+} // namespace mdc_test

--- a/TestsCpp98/test/mdc/error/exit_on_error_tests.cpp
+++ b/TestsCpp98/test/mdc/error/exit_on_error_tests.cpp
@@ -1,0 +1,101 @@
+/**
+ * Mir Drualga Common For C++98
+ * Copyright (C) 2021  Mir Drualga
+ *
+ * This file is part of Mir Drualga Common For C++98.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any program (or a modified version of that program and its
+ *  libraries), containing parts covered by the terms of an incompatible
+ *  license, the licensors of this Program grant you additional permission
+ *  to convey the resulting work.
+ */
+
+#include "exit_on_error_tests.hpp"
+
+#include <mdc/error/exit_on_error.hpp>
+
+namespace mdc {
+namespace {
+
+static void AssertExitOnGeneralError() {
+  ::mdc::error::ExitOnGeneralError(
+      L"Error Test",
+      L"%ls, %d, %X",
+      __FILEW__,
+      __LINE__,
+      L"Twenty-five",
+      25,
+      25
+  );
+}
+
+static void AssertExitOnConstantMappingError() {
+  ::mdc::error::ExitOnConstantMappingError(
+      __FILEW__,
+      __LINE__,
+      128
+  );
+}
+
+static void AssertExitOnMemoryAllocError() {
+  ::mdc::error::ExitOnMemoryAllocError(__FILEW__, __LINE__);
+}
+
+static void AssertExitOnMdcFunctionError(void) {
+  ::mdc::error::ExitOnMdcFunctionError(
+      __FILEW__,
+      __LINE__,
+      L"Mdc_NotAFunction"
+  );
+}
+
+static void AssertExitOnStaticInitError() {
+  ::mdc::error::ExitOnStaticInitError(__FILEW__, __LINE__);
+}
+
+#if defined(_WIN32) || defined(_WIN64)
+
+static void AssertExitOnWindowsFunctionError() {
+  ::mdc::error::ExitOnWindowsFunctionError(
+      __FILEW__,
+      __LINE__,
+      L"IsThisWindows9",
+      42
+  );
+}
+
+#endif /* defined(_WIN32) || defined(_WIN64) */
+
+} // namespace
+
+void ExitOnError_RunTests() {
+  AssertExitOnGeneralError();
+  AssertExitOnConstantMappingError();
+  AssertExitOnMemoryAllocError();
+  AssertExitOnMdcFunctionError();
+  AssertExitOnStaticInitError();
+
+
+#if defined(_WIN32) || defined(_WIN64)
+  AssertExitOnWindowsFunctionError();
+#endif /* defined(_WIN32) || defined(_WIN64) */
+}
+
+} // namespace mdc

--- a/TestsCpp98/test/mdc/error/exit_on_error_tests.hpp
+++ b/TestsCpp98/test/mdc/error/exit_on_error_tests.hpp
@@ -30,10 +30,12 @@
 #ifndef MDC_TESTS_CPP98_ERROR_EXIT_ON_ERROR_TESTS_HPP_
 #define MDC_TESTS_CPP98_ERROR_EXIT_ON_ERROR_TESTS_HPP_
 
-namespace mdc {
+namespace mdc_test {
+namespace error_test {
 
 void ExitOnError_RunTests();
 
-} // namespace mdc
+} // namespace error_test
+} // namespace mdc_test
 
 #endif /* MDC_TESTS_CPP98_ERROR_EXIT_ON_ERROR_TESTS_HPP_ */

--- a/TestsCpp98/test/mdc/error/exit_on_error_tests.hpp
+++ b/TestsCpp98/test/mdc/error/exit_on_error_tests.hpp
@@ -1,0 +1,39 @@
+/**
+ * Mir Drualga Common For C++98
+ * Copyright (C) 2021  Mir Drualga
+ *
+ * This file is part of Mir Drualga Common For C++98.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any program (or a modified version of that program and its
+ *  libraries), containing parts covered by the terms of an incompatible
+ *  license, the licensors of this Program grant you additional permission
+ *  to convey the resulting work.
+ */
+
+#ifndef MDC_TESTS_CPP98_ERROR_EXIT_ON_ERROR_TESTS_HPP_
+#define MDC_TESTS_CPP98_ERROR_EXIT_ON_ERROR_TESTS_HPP_
+
+namespace mdc {
+
+void ExitOnError_RunTests();
+
+} // namespace mdc
+
+#endif /* MDC_TESTS_CPP98_ERROR_EXIT_ON_ERROR_TESTS_HPP_ */

--- a/TestsCpp98/test/mdc/error_tests.cpp
+++ b/TestsCpp98/test/mdc/error_tests.cpp
@@ -31,10 +31,12 @@
 
 #include "error/exit_on_error_tests.hpp"
 
-namespace mdc {
+namespace mdc_test {
+namespace error_test {
 
-void Error_RunTests() {
+void RunTests() {
   ExitOnError_RunTests();
 }
 
-} // namespace mdc
+} // namespace error_test
+} // namespace mdc_test

--- a/TestsCpp98/test/mdc/error_tests.cpp
+++ b/TestsCpp98/test/mdc/error_tests.cpp
@@ -1,0 +1,40 @@
+/**
+ * Mir Drualga Common For C++98
+ * Copyright (C) 2021  Mir Drualga
+ *
+ * This file is part of Mir Drualga Common For C++98.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any program (or a modified version of that program and its
+ *  libraries), containing parts covered by the terms of an incompatible
+ *  license, the licensors of this Program grant you additional permission
+ *  to convey the resulting work.
+ */
+
+#include "error_tests.hpp"
+
+#include "error/exit_on_error_tests.hpp"
+
+namespace mdc {
+
+void Error_RunTests() {
+  ExitOnError_RunTests();
+}
+
+} // namespace mdc

--- a/TestsCpp98/test/mdc/error_tests.hpp
+++ b/TestsCpp98/test/mdc/error_tests.hpp
@@ -1,0 +1,39 @@
+/**
+ * Mir Drualga Common For C++98
+ * Copyright (C) 2021  Mir Drualga
+ *
+ * This file is part of Mir Drualga Common For C++98.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any program (or a modified version of that program and its
+ *  libraries), containing parts covered by the terms of an incompatible
+ *  license, the licensors of this Program grant you additional permission
+ *  to convey the resulting work.
+ */
+
+#ifndef MDC_TESTS_CPP98_ERROR_TESTS_HPP_
+#define MDC_TESTS_CPP98_ERROR_TESTS_HPP_
+
+namespace mdc {
+
+void Error_RunTests();
+
+} // namespace mdc
+
+#endif /* MDC_TESTS_CPP98_ERROR_TESTS_HPP_ */

--- a/TestsCpp98/test/mdc/error_tests.hpp
+++ b/TestsCpp98/test/mdc/error_tests.hpp
@@ -30,10 +30,12 @@
 #ifndef MDC_TESTS_CPP98_ERROR_TESTS_HPP_
 #define MDC_TESTS_CPP98_ERROR_TESTS_HPP_
 
-namespace mdc {
+namespace mdc_test {
+namespace error_test {
 
-void Error_RunTests();
+void RunTests();
 
-} // namespace mdc
+} // namespace error_test
+} // namespace mdc_test
 
 #endif /* MDC_TESTS_CPP98_ERROR_TESTS_HPP_ */

--- a/TestsCpp98/test/mdc/main.cpp
+++ b/TestsCpp98/test/mdc/main.cpp
@@ -41,9 +41,9 @@ int main(int argc, char** argv) {
 #endif /* defined(NDEBUG) */
 
   // Commented out to prevent exit.
-  // ::mdc::Error_RunTests();
+  // ::mdc_test::error_test::RunTests();
 
-  ::mdc::Std_RunTests();
+  ::mdc_test::std_test::RunTests();
 
   return 0;
 }

--- a/TestsCpp98/test/mdc/main.cpp
+++ b/TestsCpp98/test/mdc/main.cpp
@@ -1,0 +1,46 @@
+/**
+ * Mir Drualga Common For C++98
+ * Copyright (C) 2021  Mir Drualga
+ *
+ * This file is part of Mir Drualga Common For C++98.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any program (or a modified version of that program and its
+ *  libraries), containing parts covered by the terms of an incompatible
+ *  license, the licensors of this Program grant you additional permission
+ *  to convey the resulting work.
+ */
+
+#include <stdio.h>
+#include <stddef.h>
+#include <windows.h>
+
+#include "error_tests.hpp"
+
+int main(int argc, char** argv) {
+#if defined(NDEBUG)
+  MessageBoxA(NULL, "Tests must run in debug mode!", "Error", MB_OK);
+  exit(EXIT_FAILURE);
+#endif /* defined(NDEBUG) */
+
+  // Commented out to prevent exit.
+  // ::mdc::Error_RunTests();
+
+  return 0;
+}

--- a/TestsCpp98/test/mdc/std/mutex_tests.hpp
+++ b/TestsCpp98/test/mdc/std/mutex_tests.hpp
@@ -27,48 +27,15 @@
  *  to convey the resulting work.
  */
 
-#include "thread_tests.hpp"
-
-#include <stddef.h>
-#include <stdio.h>
-
-#include <mdc/std/assert.h>
-#include <mdc/std/threads.hpp>
-#include "std_example_funcs/std_increment.hpp"
+#ifndef MDC_TESTS_CPP98_STD_MUTEX_TESTS_HPP_
+#define MDC_TESTS_CPP98_STD_MUTEX_TESTS_HPP_
 
 namespace mdc_test {
 namespace std_test {
-namespace {
 
-static void AssertRaceCondition() {
-  enum {
-    kThreadsCount = 256
-  };
-
-  size_t i;
-
-  ::std::thread* threads[kThreadsCount];
-
-  int value = 0;
-
-  for (i = 0; i < kThreadsCount; i += 1) {
-    threads[i] = new ::std::thread(&Increment_ThreadFunc, &value);
-  }
-
-  for (i = 0; i < kThreadsCount; i += 1) {
-    threads[i]->join();
-    delete threads[i];
-  }
-
-  assert(value > 0);
-  assert(value <= kThreadsCount);
-}
-
-} // namespace
-
-void Thread_RunTests() {
-  AssertRaceCondition();
-}
+void Mutex_RunTests();
 
 } // namespace std_test
 } // namespace mdc_test
+
+#endif /* MDC_TESTS_CPP98_STD_THREADS_TESTS_HPP_ */

--- a/TestsCpp98/test/mdc/std/once_flag_tests.cpp
+++ b/TestsCpp98/test/mdc/std/once_flag_tests.cpp
@@ -1,0 +1,117 @@
+/**
+ * Mir Drualga Common For C++98
+ * Copyright (C) 2021  Mir Drualga
+ *
+ * This file is part of Mir Drualga Common For C++98.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any program (or a modified version of that program and its
+ *  libraries), containing parts covered by the terms of an incompatible
+ *  license, the licensors of this Program grant you additional permission
+ *  to convey the resulting work.
+ */
+
+#include "thread_tests.hpp"
+
+#include <stddef.h>
+#include <stdio.h>
+
+#include <mdc/std/assert.h>
+#include <mdc/std/mutex.hpp>
+#include <mdc/std/threads.hpp>
+#include "std_example_funcs/std_increment.hpp"
+
+namespace mdc_test {
+namespace std_test {
+namespace {
+
+enum {
+  kOnceDefaultValue = 0,
+  kOnceTargetValue = 42
+};
+
+static int once_value = kOnceDefaultValue;
+
+static void SetOnceTarget(void) {
+  size_t i;
+
+  for (i = 0; i < kOnceTargetValue; i += 1) {
+    Increment(&once_value);
+  }
+}
+
+static int SetOnceTargetMultithread(void* arg) {
+  enum {
+    kIterationCount = 8
+  };
+
+  size_t i;
+
+  ::std::once_flag* flag = reinterpret_cast<::std::once_flag*>(arg);
+
+  for (i = 0; i < kIterationCount; i += 1) {
+    ::std::call_once(*flag, &SetOnceTarget);
+  }
+
+  return 0;
+}
+
+static void AssertCallOnceSingle(void) {
+  ::std::once_flag flag;
+
+  once_value = kOnceDefaultValue;
+
+  SetOnceTargetMultithread(&flag);
+
+  assert(once_value == kOnceTargetValue);
+}
+
+static void AssertCallOnceMulti(void) {
+  enum {
+    kThreadsCount = 256
+  };
+
+  size_t i;
+
+  ::std::thread* threads[kThreadsCount];
+  ::std::once_flag flag;
+
+  once_value = kOnceDefaultValue;
+
+  for (i = 0; i < kThreadsCount; i += 1) {
+    threads[i] = new ::std::thread(&SetOnceTargetMultithread, &flag);
+  }
+
+  for (i = 0; i < kThreadsCount; i += 1) {
+    threads[i]->join();
+    delete threads[i];
+  }
+
+  assert(once_value == kOnceTargetValue);
+}
+
+} // namespace
+
+void OnceFlag_RunTests() {
+  AssertCallOnceSingle();
+  AssertCallOnceMulti();
+}
+
+} // namespace std_test
+} // namespace mdc_test

--- a/TestsCpp98/test/mdc/std/once_flag_tests.hpp
+++ b/TestsCpp98/test/mdc/std/once_flag_tests.hpp
@@ -27,23 +27,15 @@
  *  to convey the resulting work.
  */
 
-#include "std_tests.hpp"
-
-#include "std/mutex_tests.hpp"
-#include "std/once_flag_tests.hpp"
-#include "std/recursive_mutex_tests.hpp"
-#include "std/thread_tests.hpp"
+#ifndef MDC_TESTS_CPP98_STD_ONCE_FLAG_TESTS_HPP_
+#define MDC_TESTS_CPP98_STD_ONCE_FLAG_TESTS_HPP_
 
 namespace mdc_test {
 namespace std_test {
 
-void RunTests() {
-  Thread_RunTests();
-
-  Mutex_RunTests();
-  RecursiveMutex_RunTests();
-  OnceFlag_RunTests();
-}
+void OnceFlag_RunTests();
 
 } // namespace std_test
 } // namespace mdc_test
+
+#endif /* MDC_TESTS_CPP98_STD_ONCE_FLAG_TESTS_HPP_ */

--- a/TestsCpp98/test/mdc/std/recursive_mutex_tests.cpp
+++ b/TestsCpp98/test/mdc/std/recursive_mutex_tests.cpp
@@ -1,0 +1,110 @@
+/**
+ * Mir Drualga Common For C++98
+ * Copyright (C) 2021  Mir Drualga
+ *
+ * This file is part of Mir Drualga Common For C++98.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any program (or a modified version of that program and its
+ *  libraries), containing parts covered by the terms of an incompatible
+ *  license, the licensors of this Program grant you additional permission
+ *  to convey the resulting work.
+ */
+
+#include "recursive_mutex_tests.hpp"
+
+#include <mdc/std/assert.h>
+#include <mdc/std/mutex.hpp>
+#include <mdc/std/threads.hpp>
+#include "std_example_funcs/std_increment.hpp"
+
+namespace mdc_test {
+namespace std_test {
+namespace {
+
+struct MutexedValue {
+  ::std::recursive_mutex mutex;
+  int value;
+};
+
+static int RecursiveMutexedIncrement(void* arg) {
+  MutexedValue* mutexed_value = reinterpret_cast<MutexedValue*>(arg);
+
+  mutexed_value->mutex.lock();
+  mutexed_value->mutex.lock();
+  mutexed_value->mutex.lock();
+  mutexed_value->mutex.lock();
+  mutexed_value->mutex.lock();
+
+  Increment(&mutexed_value->value);
+
+  mutexed_value->mutex.unlock();
+  mutexed_value->mutex.unlock();
+  mutexed_value->mutex.unlock();
+  mutexed_value->mutex.unlock();
+  mutexed_value->mutex.unlock();
+
+  return 0;
+}
+
+static void AssertMutexLockUnlockSingle() {
+  MutexedValue value;
+
+  value.value = 0;
+
+  RecursiveMutexedIncrement(&value);
+  assert(value.value == 1);
+}
+
+static void AssertMutexLockUnlockMulti() {
+  enum {
+    kThreadsCount = 256
+  };
+
+  size_t i;
+
+  ::std::thread* threads[kThreadsCount];
+  MutexedValue value;
+
+  value.value = 0;
+
+  for (i = 0; i < kThreadsCount; i += 1) {
+    threads[i] = new ::std::thread(
+        &RecursiveMutexedIncrement,
+        &value
+    );
+  }
+
+  for (i = 0; i < kThreadsCount; i += 1) {
+    threads[i]->join();
+    delete threads[i];
+  }
+
+  assert(value.value == kThreadsCount);
+}
+
+} // namespace
+
+void RecursiveMutex_RunTests() {
+  AssertMutexLockUnlockSingle();
+  AssertMutexLockUnlockMulti();
+}
+
+} // namespace std_test
+} // namespace mdc_test

--- a/TestsCpp98/test/mdc/std/recursive_mutex_tests.hpp
+++ b/TestsCpp98/test/mdc/std/recursive_mutex_tests.hpp
@@ -27,15 +27,15 @@
  *  to convey the resulting work.
  */
 
-#ifndef MDC_TESTS_CPP98_STD_MUTEX_TESTS_HPP_
-#define MDC_TESTS_CPP98_STD_MUTEX_TESTS_HPP_
+#ifndef MDC_TESTS_CPP98_STD_RECURSIVE_MUTEX_TESTS_HPP_
+#define MDC_TESTS_CPP98_STD_RECURSIVE_MUTEX_TESTS_HPP_
 
 namespace mdc_test {
 namespace std_test {
 
-void Mutex_RunTests();
+void RecursiveMutex_RunTests();
 
 } // namespace std_test
 } // namespace mdc_test
 
-#endif /* MDC_TESTS_CPP98_STD_MUTEX_TESTS_HPP_ */
+#endif /* MDC_TESTS_CPP98_STD_RECURSIVE_MUTEX_TESTS_HPP_ */

--- a/TestsCpp98/test/mdc/std/std_example_funcs/std_increment.cpp
+++ b/TestsCpp98/test/mdc/std/std_example_funcs/std_increment.cpp
@@ -27,15 +27,35 @@
  *  to convey the resulting work.
  */
 
-#include "std_tests.hpp"
+#include "std_increment.hpp"
 
-#include "std/thread_tests.hpp"
+#if defined(_MSC_VER)
+  #include <windows.h>
+#elif defined(__GNUC__)
+  #include <unistd.h>
+#endif
 
 namespace mdc_test {
 namespace std_test {
 
-void RunTests() {
-  Thread_RunTests();
+void Increment(int* value) {
+  // Separate operations on a copy forces a race condition.
+  int temp = *value;
+  temp += 1;
+
+#if defined(_MSC_VER)
+  Sleep(1);
+#elif defined(__GNUC__)
+  usleep(1);
+#endif
+
+  *value = temp;
+}
+
+int Increment_ThreadFunc(void* value) {
+  Increment(reinterpret_cast<int*>(value));
+
+  return 0;
 }
 
 } // namespace std_test

--- a/TestsCpp98/test/mdc/std/std_example_funcs/std_increment.hpp
+++ b/TestsCpp98/test/mdc/std/std_example_funcs/std_increment.hpp
@@ -27,62 +27,17 @@
  *  to convey the resulting work.
  */
 
-#include "threads_tests.hpp"
-
-#include <stddef.h>
-#include <stdio.h>
-
-#include <mdc/std/assert.h>
-#include <mdc/std/threads.hpp>
+#ifndef MDC_TESTS_CPP98_STD_STD_EXAMPLE_FUNCS_STD_INCREMENT_HPP_
+#define MDC_TESTS_CPP98_STD_STD_EXAMPLE_FUNCS_STD_INCREMENT_HPP_
 
 namespace mdc_test {
 namespace std_test {
 
-static int Increment(void* value) {
-  int* actual_value = (int*) value;
-  
-  // Separate operations on a copy forces a race condition.
-  int temp = *actual_value;
-  temp += 1;
+void Increment(int* value);
 
-#if defined(_MSC_VER)
-  Sleep(1);
-#elif defined(__GNUC__)
-  usleep(1);
-#endif
-
-  *actual_value = temp;
-
-  return 0;
-}
-
-static void AssertRaceCondition() {
-  enum {
-    kThreadsCount = 256
-  };
-
-  size_t i;
-
-  ::std::thread* threads[kThreadsCount];
-
-  int value = 0;
-
-  for (i = 0; i < kThreadsCount; i += 1) {
-    threads[i] = new ::std::thread(&Increment, &value);
-  }
-
-  for (i = 0; i < kThreadsCount; i += 1) {
-    threads[i]->join();
-    delete threads[i];
-  }
-
-  assert(value > 0);
-  assert(value <= kThreadsCount);
-}
-
-void Threads_RunTests() {
-  AssertRaceCondition();
-}
+int Increment_ThreadFunc(void* value);
 
 } // namespace std_test
 } // namespace mdc_test
+
+#endif /* MDC_TESTS_CPP98_STD_STD_EXAMPLE_FUNCS_STD_INCREMENT_HPP_ */

--- a/TestsCpp98/test/mdc/std/thread_tests.cpp
+++ b/TestsCpp98/test/mdc/std/thread_tests.cpp
@@ -27,15 +27,44 @@
  *  to convey the resulting work.
  */
 
-#include "std_tests.hpp"
+#include "thread_tests.hpp"
 
-#include "std/thread_tests.hpp"
+#include <stddef.h>
+#include <stdio.h>
+
+#include <mdc/std/assert.h>
+#include <mdc/std/threads.hpp>
+#include "std_example_funcs/std_increment.hpp"
 
 namespace mdc_test {
 namespace std_test {
 
-void RunTests() {
-  Thread_RunTests();
+static void AssertRaceCondition() {
+  enum {
+    kThreadsCount = 256
+  };
+
+  size_t i;
+
+  ::std::thread* threads[kThreadsCount];
+
+  int value = 0;
+
+  for (i = 0; i < kThreadsCount; i += 1) {
+    threads[i] = new ::std::thread(&Increment_ThreadFunc, &value);
+  }
+
+  for (i = 0; i < kThreadsCount; i += 1) {
+    threads[i]->join();
+    delete threads[i];
+  }
+
+  assert(value > 0);
+  assert(value <= kThreadsCount);
+}
+
+void Thread_RunTests() {
+  AssertRaceCondition();
 }
 
 } // namespace std_test

--- a/TestsCpp98/test/mdc/std/thread_tests.hpp
+++ b/TestsCpp98/test/mdc/std/thread_tests.hpp
@@ -27,15 +27,15 @@
  *  to convey the resulting work.
  */
 
-#ifndef MDC_TESTS_CPP98_STD_THREADS_TESTS_HPP_
-#define MDC_TESTS_CPP98_STD_THREADS_TESTS_HPP_
+#ifndef MDC_TESTS_CPP98_STD_THREAD_TESTS_HPP_
+#define MDC_TESTS_CPP98_STD_THREAD_TESTS_HPP_
 
 namespace mdc_test {
 namespace std_test {
 
-void Threads_RunTests();
+void Thread_RunTests();
 
 } // namespace std_test
 } // namespace mdc_test
 
-#endif /* MDC_TESTS_CPP98_STD_THREADS_TESTS_HPP_ */
+#endif /* MDC_TESTS_CPP98_STD_THREAD_TESTS_HPP_ */

--- a/TestsCpp98/test/mdc/std/threads_tests.hpp
+++ b/TestsCpp98/test/mdc/std/threads_tests.hpp
@@ -27,16 +27,15 @@
  *  to convey the resulting work.
  */
 
-#include "std_tests.hpp"
-
-#include "std/threads_tests.hpp"
+#ifndef MDC_TESTS_CPP98_STD_THREADS_TESTS_HPP_
+#define MDC_TESTS_CPP98_STD_THREADS_TESTS_HPP_
 
 namespace mdc_test {
 namespace std_test {
 
-void RunTests() {
-  Threads_RunTests();
-}
+void Threads_RunTests();
 
 } // namespace std_test
 } // namespace mdc_test
+
+#endif /* MDC_TESTS_CPP98_STD_THREADS_TESTS_HPP_ */

--- a/TestsCpp98/test/mdc/std_tests.cpp
+++ b/TestsCpp98/test/mdc/std_tests.cpp
@@ -29,6 +29,7 @@
 
 #include "std_tests.hpp"
 
+#include "std/mutex_tests.hpp"
 #include "std/thread_tests.hpp"
 
 namespace mdc_test {
@@ -36,6 +37,7 @@ namespace std_test {
 
 void RunTests() {
   Thread_RunTests();
+  Mutex_RunTests();
 }
 
 } // namespace std_test

--- a/TestsCpp98/test/mdc/std_tests.cpp
+++ b/TestsCpp98/test/mdc/std_tests.cpp
@@ -27,23 +27,11 @@
  *  to convey the resulting work.
  */
 
-#include <stdio.h>
-#include <stddef.h>
-#include <windows.h>
-
-#include "error_tests.hpp"
 #include "std_tests.hpp"
 
-int main(int argc, char** argv) {
-#if defined(NDEBUG)
-  MessageBoxA(NULL, "Tests must run in debug mode!", "Error", MB_OK);
-  exit(EXIT_FAILURE);
-#endif /* defined(NDEBUG) */
+namespace mdc {
 
-  // Commented out to prevent exit.
-  // ::mdc::Error_RunTests();
-
-  ::mdc::Std_RunTests();
-
-  return 0;
+void Std_RunTests() {
 }
+
+} // namespace mdc

--- a/TestsCpp98/test/mdc/std_tests.cpp
+++ b/TestsCpp98/test/mdc/std_tests.cpp
@@ -29,9 +29,11 @@
 
 #include "std_tests.hpp"
 
-namespace mdc {
+namespace mdc_test {
+namespace std_test {
 
-void Std_RunTests() {
+void RunTests() {
 }
 
-} // namespace mdc
+} // namespace std_test
+} // namespace mdc_test

--- a/TestsCpp98/test/mdc/std_tests.cpp
+++ b/TestsCpp98/test/mdc/std_tests.cpp
@@ -30,6 +30,7 @@
 #include "std_tests.hpp"
 
 #include "std/mutex_tests.hpp"
+#include "std/recursive_mutex_tests.hpp"
 #include "std/thread_tests.hpp"
 
 namespace mdc_test {
@@ -38,6 +39,7 @@ namespace std_test {
 void RunTests() {
   Thread_RunTests();
   Mutex_RunTests();
+  RecursiveMutex_RunTests();
 }
 
 } // namespace std_test

--- a/TestsCpp98/test/mdc/std_tests.hpp
+++ b/TestsCpp98/test/mdc/std_tests.hpp
@@ -27,23 +27,13 @@
  *  to convey the resulting work.
  */
 
-#include <stdio.h>
-#include <stddef.h>
-#include <windows.h>
+#ifndef MDC_TESTS_CPP98_STD_TESTS_HPP_
+#define MDC_TESTS_CPP98_STD_TESTS_HPP_
 
-#include "error_tests.hpp"
-#include "std_tests.hpp"
+namespace mdc {
 
-int main(int argc, char** argv) {
-#if defined(NDEBUG)
-  MessageBoxA(NULL, "Tests must run in debug mode!", "Error", MB_OK);
-  exit(EXIT_FAILURE);
-#endif /* defined(NDEBUG) */
+void Std_RunTests();
 
-  // Commented out to prevent exit.
-  // ::mdc::Error_RunTests();
+} // namespace mdc
 
-  ::mdc::Std_RunTests();
-
-  return 0;
-}
+#endif /* MDC_TESTS_CPP98_STD_TESTS_HPP_ */

--- a/TestsCpp98/test/mdc/std_tests.hpp
+++ b/TestsCpp98/test/mdc/std_tests.hpp
@@ -30,10 +30,12 @@
 #ifndef MDC_TESTS_CPP98_STD_TESTS_HPP_
 #define MDC_TESTS_CPP98_STD_TESTS_HPP_
 
-namespace mdc {
+namespace mdc_test {
+namespace std_test {
 
-void Std_RunTests();
+void RunTests();
 
-} // namespace mdc
+} // namespace std_test
+} // namespace mdc_test
 
 #endif /* MDC_TESTS_CPP98_STD_TESTS_HPP_ */

--- a/TestsCpp98/test/mdc/wchar_t/example_text/example_text.cpp
+++ b/TestsCpp98/test/mdc/wchar_t/example_text/example_text.cpp
@@ -27,25 +27,18 @@
  *  to convey the resulting work.
  */
 
-#include <stdio.h>
-#include <stddef.h>
-#include <windows.h>
+#include "example_text.hpp"
 
-#include "error_tests.hpp"
-#include "std_tests.hpp"
-#include "wchar_t_tests.hpp"
+namespace mdc_test {
 
-int main(int argc, char** argv) {
-#if defined(NDEBUG)
-  MessageBoxA(NULL, "Tests must run in debug mode!", "Error", MB_OK);
-  exit(EXIT_FAILURE);
-#endif /* defined(NDEBUG) */
+const char* const kAsciiExampleText =
+    "The quick brown fox jumped over the lazy dog.";
 
-  // Commented out to prevent exit.
-  // ::mdc_test::error_test::RunTests();
+const wchar_t* const kAsciiExampleTextWide =
+    L"The quick brown fox jumped over the lazy dog.";
 
-  ::mdc_test::std_test::RunTests();
-  ::mdc_test::wide_test::RunTests();
+const char* const kUtf8ExampleText = "\xc3\xbf";
 
-  return 0;
-}
+const wchar_t* const kUtf8ExampleTextWide = L"\xff";
+
+} // namespace mdc_test

--- a/TestsCpp98/test/mdc/wchar_t/example_text/example_text.hpp
+++ b/TestsCpp98/test/mdc/wchar_t/example_text/example_text.hpp
@@ -27,25 +27,18 @@
  *  to convey the resulting work.
  */
 
-#include <stdio.h>
-#include <stddef.h>
-#include <windows.h>
+#ifndef MDC_TESTS_CPP98_WCHAR_T_EXAMPLE_TEXT_EXAMPLE_TEXT_HPP_
+#define MDC_TESTS_CPP98_WCHAR_T_EXAMPLE_TEXT_EXAMPLE_TEXT_HPP_
 
-#include "error_tests.hpp"
-#include "std_tests.hpp"
-#include "wchar_t_tests.hpp"
+#include <mdc/std/wchar.h>
 
-int main(int argc, char** argv) {
-#if defined(NDEBUG)
-  MessageBoxA(NULL, "Tests must run in debug mode!", "Error", MB_OK);
-  exit(EXIT_FAILURE);
-#endif /* defined(NDEBUG) */
+namespace mdc_test {
 
-  // Commented out to prevent exit.
-  // ::mdc_test::error_test::RunTests();
+extern const char* const kAsciiExampleText;
+extern const wchar_t* const kAsciiExampleTextWide;
+extern const char* const kUtf8ExampleText;
+extern const wchar_t* const kUtf8ExampleTextWide;
 
-  ::mdc_test::std_test::RunTests();
-  ::mdc_test::wide_test::RunTests();
+} // namespace mdc_test
 
-  return 0;
-}
+#endif /* MDC_TESTS_CPP98_WCHAR_T_EXAMPLE_TEXT_EXAMPLE_TEXT_HPP_ */

--- a/TestsCpp98/test/mdc/wchar_t/wide_decoding_tests.cpp
+++ b/TestsCpp98/test/mdc/wchar_t/wide_decoding_tests.cpp
@@ -31,7 +31,7 @@
 
 #include <mdc/std/assert.h>
 #include <mdc/wchar_t/wide_decoding.hpp>
-#include "example_text/example_text.hpp"
+#include "wide_example_text/wide_example_text.hpp"
 
 namespace mdc_test {
 namespace wide_test {

--- a/TestsCpp98/test/mdc/wchar_t/wide_decoding_tests.cpp
+++ b/TestsCpp98/test/mdc/wchar_t/wide_decoding_tests.cpp
@@ -27,25 +27,42 @@
  *  to convey the resulting work.
  */
 
-#include <stdio.h>
-#include <stddef.h>
-#include <windows.h>
+#include "wide_decoding_tests.hpp"
 
-#include "error_tests.hpp"
-#include "std_tests.hpp"
-#include "wchar_t_tests.hpp"
+#include <mdc/std/assert.h>
+#include <mdc/wchar_t/wide_decoding.hpp>
+#include "example_text/example_text.hpp"
 
-int main(int argc, char** argv) {
-#if defined(NDEBUG)
-  MessageBoxA(NULL, "Tests must run in debug mode!", "Error", MB_OK);
-  exit(EXIT_FAILURE);
-#endif /* defined(NDEBUG) */
+namespace mdc_test {
+namespace wide_test {
 
-  // Commented out to prevent exit.
-  // ::mdc_test::error_test::RunTests();
+static void AssertDecodeAscii() {
+  ::std::wstring wide_str = ::mdc::wide::DecodeAscii(kAsciiExampleText);
 
-  ::mdc_test::std_test::RunTests();
-  ::mdc_test::wide_test::RunTests();
-
-  return 0;
+  assert(wide_str == kAsciiExampleTextWide);
 }
+
+static void AssertDecodeDefaultMultibyteAscii() {
+  ::std::wstring wide_str = ::mdc::wide::DecodeDefaultMultibyte(
+      kAsciiExampleText
+  );
+
+  assert(wide_str == kAsciiExampleTextWide);
+}
+
+static void AssertDecodeUtf8() {
+  ::std::wstring wide_str = ::mdc::wide::DecodeUtf8(
+      kUtf8ExampleText
+  );
+
+  assert(wide_str == kUtf8ExampleTextWide);
+}
+
+void WideDecoding_RunTests() {
+  AssertDecodeAscii();
+  AssertDecodeDefaultMultibyteAscii();
+  AssertDecodeUtf8();
+}
+
+} // namespace wide_test
+} // namespace mdc_test

--- a/TestsCpp98/test/mdc/wchar_t/wide_decoding_tests.hpp
+++ b/TestsCpp98/test/mdc/wchar_t/wide_decoding_tests.hpp
@@ -27,25 +27,15 @@
  *  to convey the resulting work.
  */
 
-#include <stdio.h>
-#include <stddef.h>
-#include <windows.h>
+#ifndef MDC_TESTS_CPP98_WCHAR_T_WIDE_DECODING_TESTS_HPP_
+#define MDC_TESTS_CPP98_WCHAR_T_WIDE_DECODING_TESTS_HPP_
 
-#include "error_tests.hpp"
-#include "std_tests.hpp"
-#include "wchar_t_tests.hpp"
+namespace mdc_test {
+namespace wide_test {
 
-int main(int argc, char** argv) {
-#if defined(NDEBUG)
-  MessageBoxA(NULL, "Tests must run in debug mode!", "Error", MB_OK);
-  exit(EXIT_FAILURE);
-#endif /* defined(NDEBUG) */
+void WideDecoding_RunTests();
 
-  // Commented out to prevent exit.
-  // ::mdc_test::error_test::RunTests();
+} // namespace wide_test
+} // namespace mdc_test
 
-  ::mdc_test::std_test::RunTests();
-  ::mdc_test::wide_test::RunTests();
-
-  return 0;
-}
+#endif /* MDC_TESTS_CPP98_WCHAR_T_WIDE_DECODING_TESTS_HPP_ */

--- a/TestsCpp98/test/mdc/wchar_t/wide_encoding_tests.cpp
+++ b/TestsCpp98/test/mdc/wchar_t/wide_encoding_tests.cpp
@@ -27,25 +27,42 @@
  *  to convey the resulting work.
  */
 
-#include <stdio.h>
-#include <stddef.h>
-#include <windows.h>
+#include "wide_encoding_tests.hpp"
 
-#include "error_tests.hpp"
-#include "std_tests.hpp"
-#include "wchar_t_tests.hpp"
+#include <mdc/std/assert.h>
+#include <mdc/wchar_t/wide_encoding.hpp>
+#include "example_text/example_text.hpp"
 
-int main(int argc, char** argv) {
-#if defined(NDEBUG)
-  MessageBoxA(NULL, "Tests must run in debug mode!", "Error", MB_OK);
-  exit(EXIT_FAILURE);
-#endif /* defined(NDEBUG) */
+namespace mdc_test {
+namespace wide_test {
 
-  // Commented out to prevent exit.
-  // ::mdc_test::error_test::RunTests();
+static void AssertEncodeAscii() {
+  ::std::string ascii_str = ::mdc::wide::EncodeAscii(kAsciiExampleTextWide);
 
-  ::mdc_test::std_test::RunTests();
-  ::mdc_test::wide_test::RunTests();
-
-  return 0;
+  assert(ascii_str == kAsciiExampleText);
 }
+
+static void AssertEncodeDefaultMultibyteAscii() {
+  ::std::string multibyte_ascii_str = ::mdc::wide::EncodeDefaultMultibyte(
+      kAsciiExampleTextWide
+  );
+
+  assert(multibyte_ascii_str == kAsciiExampleText);
+}
+
+static void AssertEncodeUtf8() {
+  ::std::string utf8_str = ::mdc::wide::EncodeUtf8(
+      kUtf8ExampleTextWide
+  );
+
+  assert(utf8_str == kUtf8ExampleText);
+}
+
+void WideEncoding_RunTests() {
+  AssertEncodeAscii();
+  AssertEncodeDefaultMultibyteAscii();
+  AssertEncodeUtf8();
+}
+
+} // namespace wide_test
+} // namespace mdc_test

--- a/TestsCpp98/test/mdc/wchar_t/wide_encoding_tests.cpp
+++ b/TestsCpp98/test/mdc/wchar_t/wide_encoding_tests.cpp
@@ -31,7 +31,7 @@
 
 #include <mdc/std/assert.h>
 #include <mdc/wchar_t/wide_encoding.hpp>
-#include "example_text/example_text.hpp"
+#include "wide_example_text/wide_example_text.hpp"
 
 namespace mdc_test {
 namespace wide_test {

--- a/TestsCpp98/test/mdc/wchar_t/wide_encoding_tests.hpp
+++ b/TestsCpp98/test/mdc/wchar_t/wide_encoding_tests.hpp
@@ -27,25 +27,15 @@
  *  to convey the resulting work.
  */
 
-#include <stdio.h>
-#include <stddef.h>
-#include <windows.h>
+#ifndef MDC_TESTS_CPP98_WCHAR_T_WIDE_ENCODING_TESTS_HPP_
+#define MDC_TESTS_CPP98_WCHAR_T_WIDE_ENCODING_TESTS_HPP_
 
-#include "error_tests.hpp"
-#include "std_tests.hpp"
-#include "wchar_t_tests.hpp"
+namespace mdc_test {
+namespace wide_test {
 
-int main(int argc, char** argv) {
-#if defined(NDEBUG)
-  MessageBoxA(NULL, "Tests must run in debug mode!", "Error", MB_OK);
-  exit(EXIT_FAILURE);
-#endif /* defined(NDEBUG) */
+void WideEncoding_RunTests();
 
-  // Commented out to prevent exit.
-  // ::mdc_test::error_test::RunTests();
+} // namespace wide_test
+} // namespace mdc_test
 
-  ::mdc_test::std_test::RunTests();
-  ::mdc_test::wide_test::RunTests();
-
-  return 0;
-}
+#endif /* MDC_TESTS_CPP98_WCHAR_T_WIDE_ENCODING_TESTS_HPP_ */

--- a/TestsCpp98/test/mdc/wchar_t/wide_example_text/wide_example_text.cpp
+++ b/TestsCpp98/test/mdc/wchar_t/wide_example_text/wide_example_text.cpp
@@ -27,9 +27,10 @@
  *  to convey the resulting work.
  */
 
-#include "example_text.hpp"
+#include "wide_example_text.hpp"
 
 namespace mdc_test {
+namespace wide_test {
 
 const char* const kAsciiExampleText =
     "The quick brown fox jumped over the lazy dog.";
@@ -41,4 +42,5 @@ const char* const kUtf8ExampleText = "\xc3\xbf";
 
 const wchar_t* const kUtf8ExampleTextWide = L"\xff";
 
+} // namespace wide_test
 } // namespace mdc_test

--- a/TestsCpp98/test/mdc/wchar_t/wide_example_text/wide_example_text.hpp
+++ b/TestsCpp98/test/mdc/wchar_t/wide_example_text/wide_example_text.hpp
@@ -27,18 +27,20 @@
  *  to convey the resulting work.
  */
 
-#ifndef MDC_TESTS_CPP98_WCHAR_T_EXAMPLE_TEXT_EXAMPLE_TEXT_HPP_
-#define MDC_TESTS_CPP98_WCHAR_T_EXAMPLE_TEXT_EXAMPLE_TEXT_HPP_
+#ifndef MDC_TESTS_CPP98_WCHAR_T_WIDE_EXAMPLE_TEXT_WIDE_EXAMPLE_TEXT_HPP_
+#define MDC_TESTS_CPP98_WCHAR_T_WIDE_EXAMPLE_TEXT_WIDE_EXAMPLE_TEXT_HPP_
 
 #include <mdc/std/wchar.h>
 
 namespace mdc_test {
+namespace wide_test {
 
 extern const char* const kAsciiExampleText;
 extern const wchar_t* const kAsciiExampleTextWide;
 extern const char* const kUtf8ExampleText;
 extern const wchar_t* const kUtf8ExampleTextWide;
 
+} // namespace wide_test
 } // namespace mdc_test
 
-#endif /* MDC_TESTS_CPP98_WCHAR_T_EXAMPLE_TEXT_EXAMPLE_TEXT_HPP_ */
+#endif /* MDC_TESTS_CPP98_WCHAR_T_WIDE_EXAMPLE_TEXT_WIDE_EXAMPLE_TEXT_HPP_ */

--- a/TestsCpp98/test/mdc/wchar_t_tests.cpp
+++ b/TestsCpp98/test/mdc/wchar_t_tests.cpp
@@ -1,0 +1,44 @@
+/**
+ * Mir Drualga Common For C++98
+ * Copyright (C) 2021  Mir Drualga
+ *
+ * This file is part of Mir Drualga Common For C++98.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any program (or a modified version of that program and its
+ *  libraries), containing parts covered by the terms of an incompatible
+ *  license, the licensors of this Program grant you additional permission
+ *  to convey the resulting work.
+ */
+
+#include "wchar_t_tests.hpp"
+
+#include "wchar_t/wide_decoding_tests.hpp"
+#include "wchar_t/wide_encoding_tests.hpp"
+
+namespace mdc_test {
+namespace wide_test {
+
+void RunTests() {
+  WideDecoding_RunTests();
+  WideEncoding_RunTests();
+}
+
+} // namespace wide_test
+} // namespace mdc_test

--- a/TestsCpp98/test/mdc/wchar_t_tests.hpp
+++ b/TestsCpp98/test/mdc/wchar_t_tests.hpp
@@ -1,0 +1,41 @@
+/**
+ * Mir Drualga Common For C++98
+ * Copyright (C) 2021  Mir Drualga
+ *
+ * This file is part of Mir Drualga Common For C++98.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any program (or a modified version of that program and its
+ *  libraries), containing parts covered by the terms of an incompatible
+ *  license, the licensors of this Program grant you additional permission
+ *  to convey the resulting work.
+ */
+
+#ifndef MDC_TESTS_CPP98_WCHAR_T_TESTS_HPP_
+#define MDC_TESTS_CPP98_WCHAR_T_TESTS_HPP_
+
+namespace mdc_test {
+namespace wide_test {
+
+void RunTests();
+
+} // namespace wide_test
+} // namespace mdc_test
+
+#endif /* MDC_TESTS_CPP98_WCHAR_T_TESTS_HPP_ */


### PR DESCRIPTION
This adds a wrapper and partial thread implementation for C++98. This is compatible with newer C++ versions and has been tested to compile on Visual C++ 6.0 and Visual Studio 2019.

MDC For C added one new function for passing variadic argument lists.