### PR TITLE
Header export wstring encode and decode

### DIFF
--- a/MDCcpp98/include/mdc/wchar_t/wide_decoding.hpp
+++ b/MDCcpp98/include/mdc/wchar_t/wide_decoding.hpp
@@ -39,10 +39,6 @@
 namespace mdc {
 namespace wide {
 
-DLLEXPORT ::std::wstring DecodeAscii(
-    const char* ascii_c_str
-);
-
 DLLEXPORT wchar_t* DecodeAscii(
     wchar_t* wide_c_str,
     const char* ascii_c_str
@@ -50,10 +46,6 @@ DLLEXPORT wchar_t* DecodeAscii(
 
 DLLEXPORT size_t DecodeAsciiLength(
     const char* ascii_c_str
-);
-
-DLLEXPORT ::std::wstring DecodeDefaultMultibyte(
-    const char* multibyte_c_str
 );
 
 DLLEXPORT wchar_t* DecodeDefaultMultibyte(
@@ -65,10 +57,6 @@ DLLEXPORT size_t DecodeDefaultMultibyteLength(
     const char* multibyte_c_str
 );
 
-DLLEXPORT ::std::wstring DecodeUtf8(
-    const char* utf8_c_str
-);
-
 DLLEXPORT wchar_t* DecodeUtf8(
     wchar_t* wide_c_str,
     const char* utf8_c_str
@@ -77,6 +65,36 @@ DLLEXPORT wchar_t* DecodeUtf8(
 DLLEXPORT size_t DecodeUtf8Length(
     const char* utf8_c_str
 );
+
+inline ::std::wstring DecodeAscii(const char* ascii_c_str) {
+  size_t wide_c_str_length = DecodeAsciiLength(ascii_c_str);
+
+  ::std::wstring wide_str(wide_c_str_length, '\0');
+
+  DecodeAscii(&wide_str[0], ascii_c_str);
+
+  return wide_str;
+}
+
+inline ::std::wstring DecodeDefaultMultibyte(const char* multibyte_c_str) {
+  size_t wide_c_str_length = DecodeDefaultMultibyteLength(multibyte_c_str);
+
+  ::std::wstring wide_str(wide_c_str_length, '\0');
+
+  DecodeDefaultMultibyte(&wide_str[0], multibyte_c_str);
+
+  return wide_str;
+}
+
+inline ::std::wstring DecodeUtf8(const char* utf8_c_str) {
+  size_t wide_c_str_length = DecodeUtf8Length(utf8_c_str);
+
+  ::std::wstring wide_str(wide_c_str_length, '\0');
+
+  DecodeUtf8(&wide_str[0], utf8_c_str);
+
+  return wide_str;
+}
 
 } // namespace wide
 } // namespace mdc

--- a/MDCcpp98/include/mdc/wchar_t/wide_encoding.hpp
+++ b/MDCcpp98/include/mdc/wchar_t/wide_encoding.hpp
@@ -39,20 +39,12 @@
 namespace mdc {
 namespace wide {
 
-DLLEXPORT ::std::string EncodeAscii(
-    const wchar_t* wide_c_str
-);
-
 DLLEXPORT char* EncodeAscii(
     char* char_c_str,
     const wchar_t* wide_c_str
 );
 
 DLLEXPORT size_t EncodeAsciiLength(
-    const wchar_t* wide_c_str
-);
-
-DLLEXPORT ::std::string EncodeDefaultMultibyte(
     const wchar_t* wide_c_str
 );
 
@@ -65,10 +57,6 @@ DLLEXPORT size_t EncodeDefaultMultibyteLength(
     const wchar_t* wide_c_str
 );
 
-DLLEXPORT ::std::string EncodeUtf8(
-    const wchar_t* wide_c_str
-);
-
 DLLEXPORT char* EncodeUtf8(
     char* char_c_str,
     const wchar_t* wide_c_str
@@ -77,6 +65,42 @@ DLLEXPORT char* EncodeUtf8(
 DLLEXPORT size_t EncodeUtf8Length(
     const wchar_t* wide_c_str
 );
+
+inline ::std::string EncodeAscii(
+    const wchar_t* wide_c_str
+) {
+  size_t ascii_c_str_length = EncodeUtf8Length(wide_c_str);
+
+  ::std::string ascii_str(ascii_c_str_length, '\0');
+
+  EncodeUtf8(&ascii_str[0], wide_c_str);
+
+  return ascii_str;
+}
+
+inline ::std::string EncodeDefaultMultibyte(
+    const wchar_t* wide_c_str
+) {
+  size_t multibyte_c_str_length = EncodeDefaultMultibyteLength(wide_c_str);
+
+  ::std::string multibyte_str(multibyte_c_str_length, '\0');
+
+  EncodeDefaultMultibyte(&multibyte_str[0], wide_c_str);
+
+  return multibyte_str;
+}
+
+inline ::std::string EncodeUtf8(
+    const wchar_t* wide_c_str
+) {
+  size_t utf8_c_str_length = EncodeUtf8Length(wide_c_str);
+
+  ::std::string utf8_str(utf8_c_str_length, '\0');
+
+  EncodeUtf8(&utf8_str[0], wide_c_str);
+
+  return utf8_str;
+}
 
 } // namespace wide
 } // namespace mdc

--- a/MDCcpp98/src/mdc/wchar_t/wide_decoding.cpp
+++ b/MDCcpp98/src/mdc/wchar_t/wide_decoding.cpp
@@ -33,33 +33,6 @@
 
 namespace mdc {
 namespace wide {
-namespace {
-
-static ::std::wstring DecodeChar(
-    const char* char_c_str,
-    wchar_t* (*decode_func)(wchar_t*, const char*),
-    size_t (*length_func)(const char*)
-) {
-  size_t wide_c_str_length = length_func(char_c_str);
-
-  ::std::wstring wide_str(wide_c_str_length, '\0');
-
-  decode_func(&wide_str[0], char_c_str);
-
-  return wide_str;
-}
-
-} // namespace
-
-::std::wstring DecodeAscii(
-    const char* ascii_c_str
-) {
-  return DecodeChar(
-      ascii_c_str,
-      &DecodeAscii,
-      &DecodeAsciiLength
-  );
-}
 
 wchar_t* DecodeAscii(
     wchar_t* wide_c_str,
@@ -74,16 +47,6 @@ size_t DecodeAsciiLength(
   return Mdc_Wide_DecodeAsciiLength(ascii_c_str);
 }
 
-::std::wstring DecodeDefaultMultibyte(
-    const char* multibyte_c_str
-) {
-  return DecodeChar(
-      multibyte_c_str,
-      &DecodeDefaultMultibyte,
-      &DecodeDefaultMultibyteLength
-  );
-}
-
 wchar_t* DecodeDefaultMultibyte(
     wchar_t* wide_c_str,
     const char* multibyte_c_str
@@ -95,16 +58,6 @@ size_t DecodeDefaultMultibyteLength(
     const char* multibyte_c_str
 ) {
   return Mdc_Wide_DecodeDefaultMultibyteLength(multibyte_c_str);
-}
-
-::std::wstring DecodeUtf8(
-    const char* utf8_c_str
-) {
-  return DecodeChar(
-      utf8_c_str,
-      &DecodeUtf8,
-      &DecodeUtf8Length
-  );
 }
 
 wchar_t* DecodeUtf8(

--- a/MDCcpp98/src/mdc/wchar_t/wide_encoding.cpp
+++ b/MDCcpp98/src/mdc/wchar_t/wide_encoding.cpp
@@ -33,33 +33,6 @@
 
 namespace mdc {
 namespace wide {
-namespace {
-
-static ::std::string EncodeChar(
-    const wchar_t* wide_c_str,
-    char* (*encode_func)(char*, const wchar_t*),
-    size_t (*length_func)(const wchar_t*)
-) {
-  size_t char_c_str_length = length_func(wide_c_str);
-
-  ::std::string char_str(char_c_str_length, '\0');
-
-  encode_func(&char_str[0], wide_c_str);
-
-  return char_str;
-}
-
-} // namespace
-
-::std::string EncodeAscii(
-    const wchar_t* wide_c_str
-) {
-  return EncodeChar(
-      wide_c_str,
-      &EncodeAscii,
-      &EncodeAsciiLength
-  );
-}
 
 char* EncodeAscii(
     char* char_c_str,
@@ -74,16 +47,6 @@ size_t EncodeAsciiLength(
   return Mdc_Wide_EncodeAsciiLength(wide_c_str);
 }
 
-::std::string EncodeDefaultMultibyte(
-    const wchar_t* wide_c_str
-) {
-  return EncodeChar(
-      wide_c_str,
-      &EncodeDefaultMultibyte,
-      &EncodeDefaultMultibyteLength
-  );
-}
-
 char* EncodeDefaultMultibyte(
     char* char_c_str,
     const wchar_t* wide_c_str
@@ -95,16 +58,6 @@ size_t EncodeDefaultMultibyteLength(
     const wchar_t* wide_c_str
 ) {
   return Mdc_Wide_EncodeDefaultMultibyteLength(wide_c_str);
-}
-
-::std::string EncodeUtf8(
-    const wchar_t* wide_c_str
-) {
-  return EncodeChar(
-      wide_c_str,
-      &EncodeUtf8,
-      &EncodeUtf8Length
-  );
 }
 
 char* EncodeUtf8(


### PR DESCRIPTION
Fixes the issue of DLL boundary crossing when mixing of standard libraries.