### PR TITLE
CMake cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@
 *.obj
 *.so
 
+# CMake
+out/
+CMakeSettings.json
+
 # Debug / Intermediate Files
 *.ipch
 *.idb

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.10)
 
 project(MDC)
 
-add_definitions("-D_CRT_SECURE_NO_WARNINGS")
+if (MSVC)
+    add_definitions("-D_CRT_SECURE_NO_WARNINGS")
+endif (MSVC)
 
 add_subdirectory(MDC)
 add_subdirectory(Tests)

--- a/MDC/CMakeLists.txt
+++ b/MDC/CMakeLists.txt
@@ -9,60 +9,54 @@ set(CMAKE_CXX_STANDARD 98)
 set(CMAKE_CXX_STANDARD_REQUIRED true)
 
 # Header and source files
-set(INCLUDE_DIR include/mdc)
+set(INCLUDE_HEADERS
+    "dllexport_define.inc"
+    "dllexport_define.inc"
+    "include/mdc/error/exit_on_error.h"
+    "include/mdc/malloc/malloc.h"
+    "include/mdc/std/assert.h"
+    "include/mdc/std/stdbool.h"
+    "include/mdc/std/stdint.h"
+    "include/mdc/std/threads.h"
+    "include/mdc/std/wchar.h"
+    "include/mdc/wchar_t/filew.h"
+    "include/mdc/wchar_t/wide_decoding.h"
+    "include/mdc/wchar_t/wide_encoding.h"
+)
 
-function(add_include_header VAR FILE)
-    set(${VAR} ${${VAR}} ${INCLUDE_DIR}/${FILE} PARENT_SCOPE)
-endfunction()
+set(SRC_C
+    "src/mdc/error/exit_on_error.c"
+    "src/mdc/malloc/malloc.c"
+    "src/mdc/std/threads/call_once.c"
+    "src/mdc/std/threads/cond.c"
+    "src/mdc/std/threads/mutex.c"
+    "src/mdc/std/threads/threads.c"
+    "src/mdc/std/wchar/wchar.c"
+    "src/mdc/wchar_t/wide_decoding.c"
+    "src/mdc/wchar_t/wide_encoding.c"
+)
 
-set(INCLUDE_HEADERS dllexport_define.inc dllexport_define.inc)
-add_include_header(INCLUDE_HEADERS error/exit_on_error.h)
-add_include_header(INCLUDE_HEADERS malloc/malloc.h)
-add_include_header(INCLUDE_HEADERS std/assert.h)
-add_include_header(INCLUDE_HEADERS std/stdbool.h)
-add_include_header(INCLUDE_HEADERS std/stdint.h)
-add_include_header(INCLUDE_HEADERS std/threads.h)
-add_include_header(INCLUDE_HEADERS std/wchar.h)
-add_include_header(INCLUDE_HEADERS wchar_t/filew.h)
-add_include_header(INCLUDE_HEADERS wchar_t/wide_decoding.h)
-add_include_header(INCLUDE_HEADERS wchar_t/wide_encoding.h)
+set(SRC_HEADERS)
 
-set(SRC_DIR src/mdc)
-
-function(add_src_c_source VAR FILE)
-    set(${VAR} ${${VAR}} ${SRC_DIR}/${FILE} PARENT_SCOPE)
-endfunction()
-
-function(add_src_header VAR FILE)
-    set(${VAR} ${${VAR}} ${SRC_DIR}/${FILE} PARENT_SCOPE)
-endfunction()
-
-set(SRC_C "")
-add_src_c_source(SRC_C error/exit_on_error.c)
-add_src_c_source(SRC_C malloc/malloc.c)
-add_src_c_source(SRC_C std/threads/call_once.c)
-add_src_c_source(SRC_C std/threads/cond.c)
-add_src_c_source(SRC_C std/threads/mutex.c)
-add_src_c_source(SRC_C std/threads/threads.c)
-add_src_c_source(SRC_C std/wchar/wchar.c)
-add_src_c_source(SRC_C wchar_t/wide_decoding.c)
-add_src_c_source(SRC_C wchar_t/wide_encoding.c)
-
-add_library(MDCc90 STATIC ${SRC_C} ${INCLUDE_HEADERS})
+# Output static LIB
+add_library(libMDCc STATIC ${SRC_C} ${SRC_HEADERS} ${INCLUDE_HEADERS})
 
 target_include_directories(
-    MDCc90
+    libMDCc
     PUBLIC "${PROJECT_BINARY_DIR}"
 )
 
-add_library(MDCc90Dll SHARED ${SRC_C} ${INCLUDE_HEADERS})
+# Output DLL
+add_library(MDCc SHARED ${SRC_C} ${SRC_HEADERS} ${INCLUDE_HEADERS})
 
-target_compile_definitions(MDCc90Dll PRIVATE MDC_DLLEXPORT)
-target_compile_definitions(MDCc90Dll INTERFACE MDC_DLLIMPORT)
+target_compile_definitions(MDCc PRIVATE MDC_DLLEXPORT)
+target_compile_definitions(MDCc INTERFACE MDC_DLLIMPORT)
 
 target_include_directories(
-    MDCc90Dll
+    MDCc
     PUBLIC "${PROJECT_BINARY_DIR}"
 )
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SRC_C} ${INCLUDE_HEADERS})
+
+install(TARGETS MDCc)

--- a/MDC/CMakeLists.txt
+++ b/MDC/CMakeLists.txt
@@ -56,4 +56,4 @@ target_include_directories(
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SRC_C} ${INCLUDE_HEADERS})
 
-install(TARGETS MDCc)
+install(TARGETS MDCc libMDCc)

--- a/MDC/CMakeLists.txt
+++ b/MDC/CMakeLists.txt
@@ -5,9 +5,6 @@ project(MDC)
 set(CMAKE_C_STANDARD 90)
 set(CMAKE_C_STANDARD_REQUIRED true)
 
-set(CMAKE_CXX_STANDARD 98)
-set(CMAKE_CXX_STANDARD_REQUIRED true)
-
 # Header and source files
 set(INCLUDE_HEADERS
     "dllexport_define.inc"

--- a/MDCcpp98/CMakeLists.txt
+++ b/MDCcpp98/CMakeLists.txt
@@ -9,42 +9,49 @@ set(CMAKE_CXX_STANDARD 98)
 set(CMAKE_CXX_STANDARD_REQUIRED true)
 
 # Header and source files
-set(INCLUDE_DIR include/mdc)
+set(INCLUDE_HEADERS
+    "dllexport_define.inc"
+    "dllexport_define.inc"
+    "include/mdc/error/exit_on_error.hpp"
+    "include/mdc/std/condition_variable.hpp"
+    "include/mdc/std/mutex.hpp"
+    "include/mdc/std/threads.hpp"
+    "include/mdc/wchar_t/wide_decoding.hpp"
+    "include/mdc/wchar_t/wide_encoding.hpp"
+)
 
-function(add_include_header VAR FILE)
-    set(${VAR} ${${VAR}} ${INCLUDE_DIR}/${FILE} PARENT_SCOPE)
-endfunction()
+set(SRC_C
+    "src/mdc/error/exit_on_error.cpp"
+    "src/mdc/std/condition_variable/condition_variable.cpp"
+    "src/mdc/std/condition_variable/condition_variable_any.cpp"
+    "src/mdc/std/mutex/call_once.cpp"
+    "src/mdc/std/mutex/mutex.cpp"
+    "src/mdc/std/mutex/recursive_mutex.cpp"
+    "src/mdc/std/threads/threads.cpp"
+    "src/mdc/wchar_t/wide_decoding.cpp"
+    "src/mdc/wchar_t/wide_encoding.cpp"
+)
 
-set(INCLUDE_HEADERS dllexport_define.inc dllexport_define.inc)
-add_include_header(INCLUDE_HEADERS error/exit_on_error.hpp)
-add_include_header(INCLUDE_HEADERS std/condition_variable.hpp)
-add_include_header(INCLUDE_HEADERS std/mutex.hpp)
-add_include_header(INCLUDE_HEADERS std/threads.hpp)
-add_include_header(INCLUDE_HEADERS wchar_t/wide_decoding.hpp)
-add_include_header(INCLUDE_HEADERS wchar_t/wide_encoding.hpp)
+set(SRC_HEADERS)
 
-set(SRC_DIR src/mdc)
+# Output static LIB
+add_library(libMDCcpp98 STATIC ${SRC_C} ${SRC_HEADERS} ${INCLUDE_HEADERS})
 
-function(add_src_c_source VAR FILE)
-    set(${VAR} ${${VAR}} ${SRC_DIR}/${FILE} PARENT_SCOPE)
-endfunction()
+target_include_directories(
+    libMDCcpp98
+    PUBLIC "${PROJECT_BINARY_DIR}"
+    PUBLIC "../MDC/include/"
+)
 
-function(add_src_header VAR FILE)
-    set(${VAR} ${${VAR}} ${SRC_DIR}/${FILE} PARENT_SCOPE)
-endfunction()
+target_link_libraries(libMDCcpp98 libMDCc)
 
-set(SRC_C "")
-add_src_c_source(SRC_C error/exit_on_error.cpp)
-add_src_c_source(SRC_C std/condition_variable/condition_variable.cpp)
-add_src_c_source(SRC_C std/condition_variable/condition_variable_any.cpp)
-add_src_c_source(SRC_C std/mutex/call_once.cpp)
-add_src_c_source(SRC_C std/mutex/mutex.cpp)
-add_src_c_source(SRC_C std/mutex/recursive_mutex.cpp)
-add_src_c_source(SRC_C std/threads/threads.cpp)
-add_src_c_source(SRC_C wchar_t/wide_decoding.cpp)
-add_src_c_source(SRC_C wchar_t/wide_encoding.cpp)
+add_dependencies(libMDCcpp98 libMDCc)
 
-add_library(MDCcpp98 STATIC ${SRC_C} ${INCLUDE_HEADERS})
+# Output DLL
+add_library(MDCcpp98 SHARED ${SRC_C} ${SRC_HEADERS} ${INCLUDE_HEADERS})
+
+target_compile_definitions(MDCcpp98 PRIVATE MDC_CPP98_DLLEXPORT)
+target_compile_definitions(MDCcpp98 INTERFACE MDC_CPP98_DLLEXPORT)
 
 target_include_directories(
     MDCcpp98
@@ -52,23 +59,9 @@ target_include_directories(
     PUBLIC "../MDC/include/"
 )
 
-target_link_libraries(MDCcpp98 MDCc90)
-
-add_dependencies(MDCcpp98 MDCc90)
-
-add_library(MDCcpp98Dll SHARED ${SRC_C} ${INCLUDE_HEADERS})
-
-target_compile_definitions(MDCcpp98Dll PRIVATE MDC_CPP98_DLLEXPORT)
-target_compile_definitions(MDCcpp98Dll INTERFACE MDC_CPP98_DLLEXPORT)
-
-target_include_directories(
-    MDCcpp98Dll
-    PUBLIC "${PROJECT_BINARY_DIR}"
-    PUBLIC "../MDC/include/"
-)
-
-target_link_libraries(MDCcpp98Dll MDCc90)
-
-add_dependencies(MDCcpp98Dll MDCc90)
+target_link_libraries(MDCcpp98 libMDCc)
+add_dependencies(MDCcpp98 libMDCc)
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SRC_C} ${INCLUDE_HEADERS})
+
+install(TARGETS MDCcpp98)

--- a/MDCcpp98/CMakeLists.txt
+++ b/MDCcpp98/CMakeLists.txt
@@ -64,4 +64,4 @@ add_dependencies(MDCcpp98 libMDCc)
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SRC_C} ${INCLUDE_HEADERS})
 
-install(TARGETS MDCcpp98)
+install(TARGETS MDCcpp98 libMDCcpp98)

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -5,49 +5,39 @@ project(Tests)
 set(CMAKE_C_STANDARD 90)
 set(CMAKE_C_STANDARD_REQUIRED true)
 
-set(CMAKE_CXX_STANDARD 98)
-set(CMAKE_CXX_STANDARD_REQUIRED true)
-
 # Header and source files
-set(SRC_DIR tests/mdc)
+set(SRC_C
+    "tests/mdc/error/exit_on_error_tests.c"
+    "tests/mdc/std/assert_tests.c"
+    "tests/mdc/std/stdbool_tests.c"
+    "tests/mdc/std/stdint_tests.c"
+    "tests/mdc/std/threads_tests.c"
+    "tests/mdc/wchar_t/wide_example_text/wide_example_text.c"
+    "tests/mdc/wchar_t/filew_tests.c"
+    "tests/mdc/wchar_t/wide_decoding_tests.c"
+    "tests/mdc/wchar_t/wide_encoding_tests.c"
+    "tests/mdc/error_tests.c"
+    "tests/mdc/main.c"
+    "tests/mdc/std_tests.c"
+    "tests/mdc/wchar_t_tests.c"
+)
 
-function(add_src_c_source VAR FILE)
-    set(${VAR} ${${VAR}} ${SRC_DIR}/${FILE} PARENT_SCOPE)
-endfunction()
+set(SRC_HEADER
+    "tests/mdc/error/exit_on_error_tests.h"
+    "tests/mdc/std/assert_tests.h"
+    "tests/mdc/std/stdbool_tests.h"
+    "tests/mdc/std/stdint_tests.h"
+    "tests/mdc/std/threads_tests.h"
+    "tests/mdc/wchar_t/wide_example_text/wide_example_text.h"
+    "tests/mdc/wchar_t/filew_tests.h"
+    "tests/mdc/wchar_t/wide_decoding_tests.h"
+    "tests/mdc/wchar_t/wide_encoding_tests.h"
+    "tests/mdc/error_tests.h"
+    "tests/mdc/std_tests.h"
+    "tests/mdc/wchar_t_tests.h"
+)
 
-set(SRC_C "")
-add_src_c_source(SRC_C error/exit_on_error_tests.c)
-add_src_c_source(SRC_C std/assert_tests.c)
-add_src_c_source(SRC_C std/stdbool_tests.c)
-add_src_c_source(SRC_C std/stdint_tests.c)
-add_src_c_source(SRC_C std/threads_tests.c)
-add_src_c_source(SRC_C wchar_t/wide_example_text/wide_example_text.c)
-add_src_c_source(SRC_C wchar_t/filew_tests.c)
-add_src_c_source(SRC_C wchar_t/wide_decoding_tests.c)
-add_src_c_source(SRC_C wchar_t/wide_encoding_tests.c)
-add_src_c_source(SRC_C error_tests.c)
-add_src_c_source(SRC_C main.c)
-add_src_c_source(SRC_C std_tests.c)
-add_src_c_source(SRC_C wchar_t_tests.c)
-
-function(add_src_header VAR FILE)
-    set(${VAR} ${${VAR}} ${SRC_DIR}/${FILE} PARENT_SCOPE)
-endfunction()
-
-set(SRC_HEADER "")
-add_src_header(SRC_HEADER error/exit_on_error_tests.h)
-add_src_header(SRC_HEADER std/assert_tests.h)
-add_src_header(SRC_HEADER std/stdbool_tests.h)
-add_src_header(SRC_HEADER std/stdint_tests.h)
-add_src_header(SRC_HEADER std/threads_tests.h)
-add_src_header(SRC_HEADER wchar_t/wide_example_text/wide_example_text.h)
-add_src_header(SRC_HEADER wchar_t/filew_tests.h)
-add_src_header(SRC_HEADER wchar_t/wide_decoding_tests.h)
-add_src_header(SRC_HEADER wchar_t/wide_encoding_tests.h)
-add_src_header(SRC_HEADER error_tests.h)
-add_src_header(SRC_HEADER std_tests.h)
-add_src_header(SRC_HEADER wchar_t_tests.h)
-
+# Output test EXE
 add_executable(Tests ${SRC_C} ${SRC_HEADER})
 
 target_include_directories(
@@ -56,8 +46,9 @@ target_include_directories(
     PUBLIC "../MDC/include/"
 )
 
-target_link_libraries(Tests MDCc90)
-
-add_dependencies(Tests MDCc90)
+target_link_libraries(Tests MDCc)
+add_dependencies(Tests MDCc)
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SRC_C} ${SRC_HEADER})
+
+install(TARGETS Tests)

--- a/TestsCpp98/CMakeLists.txt
+++ b/TestsCpp98/CMakeLists.txt
@@ -9,45 +9,38 @@ set(CMAKE_CXX_STANDARD 98)
 set(CMAKE_CXX_STANDARD_REQUIRED true)
 
 # Header and source files
-set(SRC_DIR tests/mdc)
+set(SRC_C
+    "tests/mdc/error/exit_on_error_tests.cpp"
+    "tests/mdc/std/std_example_funcs/std_increment.cpp"
+    "tests/mdc/std/mutex_tests.cpp"
+    "tests/mdc/std/once_flag_tests.cpp"
+    "tests/mdc/std/recursive_mutex_tests.cpp"
+    "tests/mdc/std/thread_tests.cpp"
+    "tests/mdc/wchar_t/wide_example_text/wide_example_text.cpp"
+    "tests/mdc/wchar_t/wide_decoding_tests.cpp"
+    "tests/mdc/wchar_t/wide_encoding_tests.cpp"
+    "tests/mdc/error_tests.cpp"
+    "tests/mdc/main.cpp"
+    "tests/mdc/std_tests.cpp"
+    "tests/mdc/wchar_t_tests.cpp"
+)
 
-function(add_src_c_source VAR FILE)
-    set(${VAR} ${${VAR}} ${SRC_DIR}/${FILE} PARENT_SCOPE)
-endfunction()
+set(SRC_HEADER
+    "tests/mdc/error/exit_on_error_tests.hpp"
+    "tests/mdc/std/std_example_funcs/std_increment.hpp"
+    "tests/mdc/std/mutex_tests.hpp"
+    "tests/mdc/std/once_flag_tests.hpp"
+    "tests/mdc/std/recursive_mutex_tests.hpp"
+    "tests/mdc/std/thread_tests.hpp"
+    "tests/mdc/wchar_t/wide_example_text/wide_example_text.hpp"
+    "tests/mdc/wchar_t/wide_decoding_tests.hpp"
+    "tests/mdc/wchar_t/wide_encoding_tests.hpp"
+    "tests/mdc/error_tests.hpp"
+    "tests/mdc/std_tests.hpp"
+    "tests/mdc/wchar_t_tests.hpp"
+)
 
-set(SRC_C "")
-add_src_c_source(SRC_C error/exit_on_error_tests.cpp)
-add_src_c_source(SRC_C std/std_example_funcs/std_increment.cpp)
-add_src_c_source(SRC_C std/mutex_tests.cpp)
-add_src_c_source(SRC_C std/once_flag_tests.cpp)
-add_src_c_source(SRC_C std/recursive_mutex_tests.cpp)
-add_src_c_source(SRC_C std/thread_tests.cpp)
-add_src_c_source(SRC_C wchar_t/wide_example_text/wide_example_text.cpp)
-add_src_c_source(SRC_C wchar_t/wide_decoding_tests.cpp)
-add_src_c_source(SRC_C wchar_t/wide_encoding_tests.cpp)
-add_src_c_source(SRC_C error_tests.cpp)
-add_src_c_source(SRC_C main.cpp)
-add_src_c_source(SRC_C std_tests.cpp)
-add_src_c_source(SRC_C wchar_t_tests.cpp)
-
-function(add_src_header VAR FILE)
-    set(${VAR} ${${VAR}} ${SRC_DIR}/${FILE} PARENT_SCOPE)
-endfunction()
-
-set(SRC_HEADER "")
-add_src_header(SRC_HEADER error/exit_on_error_tests.hpp)
-add_src_header(SRC_HEADER std/std_example_funcs/std_increment.hpp)
-add_src_header(SRC_HEADER std/mutex_tests.hpp)
-add_src_header(SRC_HEADER std/once_flag_tests.hpp)
-add_src_header(SRC_HEADER std/recursive_mutex_tests.hpp)
-add_src_header(SRC_HEADER std/thread_tests.hpp)
-add_src_header(SRC_HEADER wchar_t/wide_example_text/wide_example_text.hpp)
-add_src_header(SRC_HEADER wchar_t/wide_decoding_tests.hpp)
-add_src_header(SRC_HEADER wchar_t/wide_encoding_tests.hpp)
-add_src_header(SRC_HEADER error_tests.hpp)
-add_src_header(SRC_HEADER std_tests.hpp)
-add_src_header(SRC_HEADER wchar_t_tests.hpp)
-
+# Output test EXE
 add_executable(TestsCpp98 ${SRC_C} ${SRC_HEADER})
 
 target_include_directories(
@@ -57,10 +50,9 @@ target_include_directories(
     PUBLIC "../MDC/include/"
 )
 
-target_link_libraries(TestsCpp98 MDCc90)
-target_link_libraries(TestsCpp98 MDCcpp98)
-
-add_dependencies(TestsCpp98 MDCc90)
-add_dependencies(TestsCpp98 MDCcpp98)
+target_link_libraries(TestsCpp98 MDCc MDCcpp98)
+add_dependencies(TestsCpp98 MDCc MDCcpp98)
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SRC_C} ${SRC_HEADER})
+
+install(TARGETS TestsCpp98)


### PR DESCRIPTION
These changes clean up the CMakeLists.txt files to output names that are more consistent with the VC6 projects. The unnecessary functions have also been removed. The install commands have been added to each project.