### PR TITLE
Fix CMake header include interface

### DIFF
--- a/MDC/CMakeLists.txt
+++ b/MDC/CMakeLists.txt
@@ -40,7 +40,7 @@ add_library(libMDCc STATIC ${SRC_C} ${SRC_HEADERS} ${INCLUDE_HEADERS})
 
 target_include_directories(
     libMDCc
-    PUBLIC "${PROJECT_BINARY_DIR}"
+    PUBLIC "include"
 )
 
 # Output DLL
@@ -51,7 +51,7 @@ target_compile_definitions(MDCc INTERFACE MDC_DLLIMPORT)
 
 target_include_directories(
     MDCc
-    PUBLIC "${PROJECT_BINARY_DIR}"
+    PUBLIC "include"
 )
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SRC_C} ${INCLUDE_HEADERS})

--- a/MDC/CMakeLists.txt
+++ b/MDC/CMakeLists.txt
@@ -38,10 +38,7 @@ set(SRC_HEADERS)
 # Output static LIB
 add_library(libMDCc STATIC ${SRC_C} ${SRC_HEADERS} ${INCLUDE_HEADERS})
 
-target_include_directories(
-    libMDCc
-    PUBLIC "include"
-)
+target_include_directories(libMDCc PUBLIC "include")
 
 # Output DLL
 add_library(MDCc SHARED ${SRC_C} ${SRC_HEADERS} ${INCLUDE_HEADERS})
@@ -49,10 +46,7 @@ add_library(MDCc SHARED ${SRC_C} ${SRC_HEADERS} ${INCLUDE_HEADERS})
 target_compile_definitions(MDCc PRIVATE MDC_DLLEXPORT)
 target_compile_definitions(MDCc INTERFACE MDC_DLLIMPORT)
 
-target_include_directories(
-    MDCc
-    PUBLIC "include"
-)
+target_include_directories(MDCc PUBLIC "include")
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SRC_C} ${INCLUDE_HEADERS})
 

--- a/MDCcpp98/CMakeLists.txt
+++ b/MDCcpp98/CMakeLists.txt
@@ -39,8 +39,7 @@ add_library(libMDCcpp98 STATIC ${SRC_C} ${SRC_HEADERS} ${INCLUDE_HEADERS})
 
 target_include_directories(
     libMDCcpp98
-    PUBLIC "${PROJECT_BINARY_DIR}"
-    PUBLIC "../MDC/include/"
+    PUBLIC "include"
 )
 
 target_link_libraries(libMDCcpp98 libMDCc)
@@ -55,8 +54,7 @@ target_compile_definitions(MDCcpp98 INTERFACE MDC_CPP98_DLLEXPORT)
 
 target_include_directories(
     MDCcpp98
-    PUBLIC "${PROJECT_BINARY_DIR}"
-    PUBLIC "../MDC/include/"
+    PUBLIC "include"
 )
 
 target_link_libraries(MDCcpp98 libMDCc)

--- a/MDCcpp98/CMakeLists.txt
+++ b/MDCcpp98/CMakeLists.txt
@@ -43,7 +43,6 @@ target_include_directories(
 )
 
 target_link_libraries(libMDCcpp98 libMDCc)
-
 add_dependencies(libMDCcpp98 libMDCc)
 
 # Output DLL
@@ -57,8 +56,8 @@ target_include_directories(
     PUBLIC "include"
 )
 
-target_link_libraries(MDCcpp98 libMDCc)
-add_dependencies(MDCcpp98 libMDCc)
+target_link_libraries(MDCcpp98 MDCc)
+add_dependencies(MDCcpp98 MDCc)
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SRC_C} ${INCLUDE_HEADERS})
 

--- a/MDCcpp98/CMakeLists.txt
+++ b/MDCcpp98/CMakeLists.txt
@@ -37,10 +37,7 @@ set(SRC_HEADERS)
 # Output static LIB
 add_library(libMDCcpp98 STATIC ${SRC_C} ${SRC_HEADERS} ${INCLUDE_HEADERS})
 
-target_include_directories(
-    libMDCcpp98
-    PUBLIC "include"
-)
+target_include_directories(libMDCcpp98 PUBLIC "include")
 
 target_link_libraries(libMDCcpp98 libMDCc)
 add_dependencies(libMDCcpp98 libMDCc)
@@ -51,10 +48,7 @@ add_library(MDCcpp98 SHARED ${SRC_C} ${SRC_HEADERS} ${INCLUDE_HEADERS})
 target_compile_definitions(MDCcpp98 PRIVATE MDC_CPP98_DLLEXPORT)
 target_compile_definitions(MDCcpp98 INTERFACE MDC_CPP98_DLLEXPORT)
 
-target_include_directories(
-    MDCcpp98
-    PUBLIC "include"
-)
+target_include_directories(MDCcpp98 PUBLIC "include")
 
 target_link_libraries(MDCcpp98 MDCc)
 add_dependencies(MDCcpp98 MDCc)

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -40,12 +40,6 @@ set(SRC_HEADER
 # Output test EXE
 add_executable(Tests ${SRC_C} ${SRC_HEADER})
 
-target_include_directories(
-    Tests
-    PUBLIC "${PROJECT_BINARY_DIR}"
-    PUBLIC "../MDC/include/"
-)
-
 target_link_libraries(Tests MDCc)
 add_dependencies(Tests MDCc)
 

--- a/TestsCpp98/CMakeLists.txt
+++ b/TestsCpp98/CMakeLists.txt
@@ -43,13 +43,6 @@ set(SRC_HEADER
 # Output test EXE
 add_executable(TestsCpp98 ${SRC_C} ${SRC_HEADER})
 
-target_include_directories(
-    TestsCpp98
-    PUBLIC "${PROJECT_BINARY_DIR}"
-    PUBLIC "../MDCcpp98/include/"
-    PUBLIC "../MDC/include/"
-)
-
 target_link_libraries(TestsCpp98 MDCc MDCcpp98)
 add_dependencies(TestsCpp98 MDCc MDCcpp98)
 


### PR DESCRIPTION
These changes fix the CMake header file interface. Incorrect usage allowed the project to compile, but not external projects dependent on this project.