### PR TITLE
Add the AGPLv3+ license header to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,53 @@
+# Mir Drualga Common For C
+# Copyright (C) 2020-2021  Mir Drualga
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Additional permissions under GNU Affero General Public License version 3
+# section 7
+#
+# If you modify this Program, or any covered work, by linking or combining
+# it with any program (or a modified version of that program and its
+# libraries), containing parts covered by the terms of an incompatible
+# license, the licensors of this Program grant you additional permission
+# to convey the resulting work.
+
+# Mir Drualga Common For C++98
+# Copyright (C) 2021  Mir Drualga
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Additional permissions under GNU Affero General Public License version 3
+# section 7
+#
+# If you modify this Program, or any covered work, by linking or combining
+# it with any program (or a modified version of that program and its
+# libraries), containing parts covered by the terms of an incompatible
+# license, the licensors of this Program grant you additional permission
+# to convey the resulting work.
+
 cmake_minimum_required(VERSION 3.10)
 
 project(MDC)

--- a/MDC/CMakeLists.txt
+++ b/MDC/CMakeLists.txt
@@ -1,3 +1,28 @@
+# Mir Drualga Common For C
+# Copyright (C) 2020-2021  Mir Drualga
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Additional permissions under GNU Affero General Public License version 3
+# section 7
+#
+# If you modify this Program, or any covered work, by linking or combining
+# it with any program (or a modified version of that program and its
+# libraries), containing parts covered by the terms of an incompatible
+# license, the licensors of this Program grant you additional permission
+# to convey the resulting work.
+
 cmake_minimum_required(VERSION 3.10)
 
 project(MDC)

--- a/MDCcpp98/CMakeLists.txt
+++ b/MDCcpp98/CMakeLists.txt
@@ -1,3 +1,28 @@
+# Mir Drualga Common For C++98
+# Copyright (C) 2021  Mir Drualga
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Additional permissions under GNU Affero General Public License version 3
+# section 7
+#
+# If you modify this Program, or any covered work, by linking or combining
+# it with any program (or a modified version of that program and its
+# libraries), containing parts covered by the terms of an incompatible
+# license, the licensors of this Program grant you additional permission
+# to convey the resulting work.
+
 cmake_minimum_required(VERSION 3.10)
 
 project(MDCcpp98)

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,3 +1,28 @@
+# Mir Drualga Common For C
+# Copyright (C) 2020-2021  Mir Drualga
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Additional permissions under GNU Affero General Public License version 3
+# section 7
+#
+# If you modify this Program, or any covered work, by linking or combining
+# it with any program (or a modified version of that program and its
+# libraries), containing parts covered by the terms of an incompatible
+# license, the licensors of this Program grant you additional permission
+# to convey the resulting work.
+
 cmake_minimum_required(VERSION 3.10)
 
 project(Tests)

--- a/TestsCpp98/CMakeLists.txt
+++ b/TestsCpp98/CMakeLists.txt
@@ -1,3 +1,28 @@
+# Mir Drualga Common For C++98
+# Copyright (C) 2021  Mir Drualga
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Additional permissions under GNU Affero General Public License version 3
+# section 7
+#
+# If you modify this Program, or any covered work, by linking or combining
+# it with any program (or a modified version of that program and its
+# libraries), containing parts covered by the terms of an incompatible
+# license, the licensors of this Program grant you additional permission
+# to convey the resulting work.
+
 cmake_minimum_required(VERSION 3.10)
 
 project(TestsCpp98)


### PR DESCRIPTION
These changes add the AGPLv3+ headers to the the CMakeLists.txt files.