### PR TITLE
Add options to enable tests (off by default)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,15 @@ if (MSVC)
 endif (MSVC)
 
 add_subdirectory(MDC)
-add_subdirectory(Tests)
+
+option(ENABLE_MDC_C_TESTS "Enable tests for MDCc.")
+if (ENABLE_MDC_C_TESTS)
+    add_subdirectory(Tests)
+endif (ENABLE_MDC_C_TESTS)
+
 add_subdirectory(MDCcpp98)
-add_subdirectory(TestsCpp98)
+
+option(ENABLE_MDC_CPP98_TESTS "Enable tests for MDCc.")
+if (ENABLE_MDC_CPP98_TESTS)
+    add_subdirectory(TestsCpp98)
+endif (ENABLE_MDC_CPP98_TESTS)


### PR DESCRIPTION
These changes add options to enable the MDC tests in CMake. They are off by default to prevent name conflicts.