### PR TITLE
Fix GCC/MinGW compilation

### DIFF
--- a/MDC/CMakeLists.txt
+++ b/MDC/CMakeLists.txt
@@ -30,6 +30,12 @@ project(MDC)
 set(CMAKE_C_STANDARD 90)
 set(CMAKE_C_STANDARD_REQUIRED true)
 
+if (MINGW)
+    set(CMAKE_IMPORT_LIBRARY_PREFIX "")
+    set(CMAKE_SHARED_LIBRARY_PREFIX "")
+    set(CMAKE_STATIC_LIBRARY_PREFIX "")
+endif (MINGW)
+
 # Header and source files
 set(INCLUDE_HEADERS
     "dllexport_define.inc"

--- a/MDC/dllexport_define.inc
+++ b/MDC/dllexport_define.inc
@@ -28,13 +28,13 @@
  */
 
 #if defined(MDC_DLLEXPORT)
-  #if defined(_MSC_VER)
+  #if defined(_MSC_VER) || defined(__MINGW32__)
     #define DLLEXPORT __declspec(dllexport)
   #elif defined(__GNUC__)
     #define DLLEXPORT __attribute__((visibility("default")))
   #endif
 #elif defined(MDC_DLLIMPORT)
-  #if defined(_MSC_VER)
+  #if defined(_MSC_VER) || defined(__MINGW32__)
     #define DLLEXPORT __declspec(dllimport)
   #elif defined(__GNUC__)
     #define DLLEXPORT

--- a/MDC/include/mdc/std/threads.h
+++ b/MDC/include/mdc/std/threads.h
@@ -36,7 +36,7 @@
 
 #else
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__MINGW32__)
   #include <windows.h>
 #elif defined(__GNUC__)
   #include <pthread.h>
@@ -62,7 +62,7 @@ enum {
 
 typedef int (*thrd_start_t)(void*);
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__MINGW32__)
 
 typedef HANDLE thrd_t;
 
@@ -90,7 +90,7 @@ enum {
   mtx_timed = 0x3
 };
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__MINGW32__)
 
 typedef struct {
   HANDLE mutex_;
@@ -111,7 +111,7 @@ DLLEXPORT int mtx_lock(mtx_t* mutex);
 DLLEXPORT int mtx_trylock(mtx_t *mutex);
 DLLEXPORT int mtx_unlock(mtx_t *mutex);
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__MINGW32__)
 
 typedef struct {
   LONG has_active_thread_;
@@ -140,7 +140,7 @@ DLLEXPORT void call_once(once_flag* flag, void (*func)(void));
  * Conditional variables
  */
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__MINGW32__)
 
 typedef struct {
   HANDLE waiter_event_;

--- a/MDC/src/mdc/std/threads/call_once.c
+++ b/MDC/src/mdc/std/threads/call_once.c
@@ -31,7 +31,7 @@
 
 #if __STDC_VERSION__ < 201112L || defined(__STDC_NO_THREADS__)
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__MINGW32__)
 
 static void CallAsActiveThread(once_flag* flag, void (*func)(void)) {
   flag->passive_thread_event_ = CreateEventA(NULL, TRUE, FALSE, NULL);

--- a/MDC/src/mdc/std/threads/cond.c
+++ b/MDC/src/mdc/std/threads/cond.c
@@ -31,7 +31,7 @@
 
 #if __STDC_VERSION__ < 201112L || defined(__STDC_NO_THREADS__)
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__MINGW32__)
 
 int cnd_init(cnd_t* cond) {
   cond->waiter_event_ = CreateEventA(NULL, TRUE, FALSE, NULL);

--- a/MDC/src/mdc/std/threads/mutex.c
+++ b/MDC/src/mdc/std/threads/mutex.c
@@ -31,7 +31,7 @@
 
 #if __STDC_VERSION__ < 201112L || defined(__STDC_NO_THREADS__)
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__MINGW32__)
 
 int mtx_init(mtx_t* mutex, int type) {
   mutex->mutex_ = CreateMutexA(NULL, FALSE, NULL);

--- a/MDC/src/mdc/std/threads/threads.c
+++ b/MDC/src/mdc/std/threads/threads.c
@@ -120,6 +120,7 @@ int thrd_join(thrd_t thr, int *res) {
   DWORD wait_result;
   BOOL is_get_exit_code_success;
   BOOL is_close_handle_success;
+  DWORD exit_code;
 
   wait_result = WaitForSingleObject(thr, INFINITE);
   if (wait_result == WAIT_FAILED) {
@@ -127,7 +128,8 @@ int thrd_join(thrd_t thr, int *res) {
   }
 
   if (res != NULL) {
-    is_get_exit_code_success = GetExitCodeThread(thr, res);
+    exit_code = *res;
+    is_get_exit_code_success = GetExitCodeThread(thr, &exit_code);
     if (!is_get_exit_code_success) {
       goto return_bad;
     }

--- a/MDC/src/mdc/std/threads/threads.c
+++ b/MDC/src/mdc/std/threads/threads.c
@@ -31,7 +31,7 @@
 
 #if __STDC_VERSION__ < 201112L || defined(__STDC_NO_THREADS__)
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__MINGW32__)
 
 #include <process.h>
 

--- a/MDCcpp98/CMakeLists.txt
+++ b/MDCcpp98/CMakeLists.txt
@@ -33,6 +33,12 @@ set(CMAKE_C_STANDARD_REQUIRED true)
 set(CMAKE_CXX_STANDARD 98)
 set(CMAKE_CXX_STANDARD_REQUIRED true)
 
+if (MINGW)
+    set(CMAKE_IMPORT_LIBRARY_PREFIX "")
+    set(CMAKE_SHARED_LIBRARY_PREFIX "")
+    set(CMAKE_STATIC_LIBRARY_PREFIX "")
+endif (MINGW)
+
 # Header and source files
 set(INCLUDE_HEADERS
     "dllexport_define.inc"

--- a/MDCcpp98/dllexport_define.inc
+++ b/MDCcpp98/dllexport_define.inc
@@ -28,13 +28,13 @@
  */
 
 #if defined(MDC_CPP98_DLLEXPORT)
-  #if defined(_MSC_VER)
+  #if defined(_MSC_VER) || defined(__MINGW32__)
     #define DLLEXPORT __declspec(dllexport)
   #elif defined(__GNUC__)
     #define DLLEXPORT __attribute__((visibility("default")))
   #endif
 #elif defined(MDC_CPP98_DLLIMPORT)
-  #if defined(_MSC_VER)
+  #if defined(_MSC_VER) || defined(__MINGW32__)
     #define DLLEXPORT __declspec(dllimport)
   #elif defined(__GNUC__)
     #define DLLEXPORT

--- a/MDCcpp98/include/mdc/std/mutex.hpp
+++ b/MDCcpp98/include/mdc/std/mutex.hpp
@@ -51,8 +51,11 @@ namespace std {
  */
 
 class DLLEXPORT mutex {
+ private:
+  typedef ::mtx_t native_type;
+
  public:
-  typedef ::mtx_t native_handle_type;
+  typedef native_type* native_handle_type;
 
   mutex() throw();
 
@@ -67,7 +70,7 @@ class DLLEXPORT mutex {
   native_handle_type native_handle();
 
  private:
-  native_handle_type mutex_;
+  native_type mutex_;
 
   // Intentionally unimplemented to "delete" them.
   mutex(const mutex&);
@@ -75,8 +78,11 @@ class DLLEXPORT mutex {
 };
 
 class DLLEXPORT recursive_mutex {
+ private:
+  typedef ::mtx_t native_type;
+
  public:
-  typedef ::mtx_t native_handle_type;
+  typedef native_type* native_handle_type;
 
   recursive_mutex() throw();
 
@@ -91,7 +97,7 @@ class DLLEXPORT recursive_mutex {
   native_handle_type native_handle();
 
  private:
-  native_handle_type mutex_;
+  native_type mutex_;
 
   // Intentionally unimplemented to "delete" them.
   recursive_mutex(const recursive_mutex&);

--- a/MDCcpp98/include/mdc/std/mutex.hpp
+++ b/MDCcpp98/include/mdc/std/mutex.hpp
@@ -38,6 +38,8 @@
 
 #include <stddef.h>
 
+#include <stdexcept>
+
 #include <mdc/std/threads.h>
 
 #include "../../../dllexport_define.inc"

--- a/MDCcpp98/include/mdc/std/mutex.hpp
+++ b/MDCcpp98/include/mdc/std/mutex.hpp
@@ -252,6 +252,8 @@ class DLLEXPORT once_flag {
   once_flag& operator=(const once_flag&);
 };
 
+DLLEXPORT void call_once(once_flag& flag, void (*func)(void));
+
 } // namespace std
 
 #include "../../../dllexport_undefine.inc"

--- a/MDCcpp98/src/mdc/std/condition_variable/condition_variable.cpp
+++ b/MDCcpp98/src/mdc/std/condition_variable/condition_variable.cpp
@@ -58,7 +58,7 @@ void condition_variable::notify_all() throw() {
 }
 
 void condition_variable::wait(unique_lock<mutex>& lock) {
-  ::cnd_wait(&this->condition_variable_, &lock.mutex()->native_handle());
+  ::cnd_wait(&this->condition_variable_, lock.mutex()->native_handle());
 }
 
 } // namespace std

--- a/MDCcpp98/src/mdc/std/mutex/call_once.cpp
+++ b/MDCcpp98/src/mdc/std/mutex/call_once.cpp
@@ -29,9 +29,9 @@
 
 #include "../../../../include/mdc/std/mutex.hpp"
 
-#include <stdexcept>
-
 #if __cplusplus < 201103L && _MSVC_LANG < 201103L
+
+#include <stdexcept>
 
 namespace std {
 

--- a/MDCcpp98/src/mdc/std/mutex/mutex.cpp
+++ b/MDCcpp98/src/mdc/std/mutex/mutex.cpp
@@ -60,7 +60,7 @@ void mutex::unlock() {
 }
 
 mutex::native_handle_type mutex::native_handle() {
-  return this->mutex_;
+  return &this->mutex_;
 }
 
 } // namespace std

--- a/MDCcpp98/src/mdc/std/mutex/mutex.cpp
+++ b/MDCcpp98/src/mdc/std/mutex/mutex.cpp
@@ -35,7 +35,7 @@
 
 namespace std {
 
-mutex::mutex() {
+mutex::mutex() throw() {
   ::mtx_init(&this->mutex_, mtx_plain);
 }
 

--- a/MDCcpp98/src/mdc/std/mutex/mutex.cpp
+++ b/MDCcpp98/src/mdc/std/mutex/mutex.cpp
@@ -29,9 +29,9 @@
 
 #include "../../../../include/mdc/std/mutex.hpp"
 
-#include <stdexcept>
-
 #if __cplusplus < 201103L && _MSVC_LANG < 201103L
+
+#include <stdexcept>
 
 namespace std {
 

--- a/MDCcpp98/src/mdc/std/mutex/recursive_mutex.cpp
+++ b/MDCcpp98/src/mdc/std/mutex/recursive_mutex.cpp
@@ -60,7 +60,7 @@ void recursive_mutex::unlock() {
 }
 
 recursive_mutex::native_handle_type recursive_mutex::native_handle() {
-  return this->mutex_;
+  return &this->mutex_;
 }
 
 } // namespace std

--- a/MDCcpp98/src/mdc/std/mutex/recursive_mutex.cpp
+++ b/MDCcpp98/src/mdc/std/mutex/recursive_mutex.cpp
@@ -35,7 +35,7 @@
 
 namespace std {
 
-recursive_mutex::recursive_mutex() {
+recursive_mutex::recursive_mutex() throw() {
   ::mtx_init(&this->mutex_, mtx_plain | mtx_recursive);
 }
 

--- a/MDCcpp98/src/mdc/std/mutex/recursive_mutex.cpp
+++ b/MDCcpp98/src/mdc/std/mutex/recursive_mutex.cpp
@@ -29,9 +29,9 @@
 
 #include "../../../../include/mdc/std/mutex.hpp"
 
-#include <stdexcept>
-
 #if __cplusplus < 201103L && _MSVC_LANG < 201103L
+
+#include <stdexcept>
 
 namespace std {
 

--- a/MDCcpp98/src/mdc/std/threads/threads.cpp
+++ b/MDCcpp98/src/mdc/std/threads/threads.cpp
@@ -61,7 +61,7 @@ void thread::detach() {
   int detach_result = thrd_detach(this->thread_);
 }
 
-void thread::swap(thread& other) {
+void thread::swap(thread& other) throw() {
   thrd_t temp = this->thread_;
   this->thread_ = other.thread_;
   other.thread_ = temp;

--- a/MDCcpp98/src/mdc/std/threads/threads.cpp
+++ b/MDCcpp98/src/mdc/std/threads/threads.cpp
@@ -29,9 +29,9 @@
 
 #include "../../../../include/mdc/std/threads.hpp"
 
-#include <stdexcept>
-
 #if __cplusplus < 201103L && _MSVC_LANG < 201103L
+
+#include <stdexcept>
 
 namespace std {
 

--- a/Tests/tests/mdc/std/threads_tests.c
+++ b/Tests/tests/mdc/std/threads_tests.c
@@ -59,7 +59,7 @@ static int Increment(void* value) {
   temp = *actual_value;
   temp += 1;
 
-  #if defined(_MSC_VER)
+  #if defined(_MSC_VER) || defined(__MINGW32__)
   Sleep(1);
   #elif defined(__GNUC__)
   usleep(1);

--- a/TestsCpp98/tests/mdc/std/once_flag_tests.cpp
+++ b/TestsCpp98/tests/mdc/std/once_flag_tests.cpp
@@ -63,7 +63,7 @@ static int SetOnceTargetMultithread(void* arg) {
 
   size_t i;
 
-  ::std::once_flag* flag = reinterpret_cast<::std::once_flag*>(arg);
+  ::std::once_flag* flag = reinterpret_cast< ::std::once_flag*>(arg);
 
   for (i = 0; i < kIterationCount; i += 1) {
     ::std::call_once(*flag, &SetOnceTarget);

--- a/TestsCpp98/tests/mdc/std/std_example_funcs/std_increment.cpp
+++ b/TestsCpp98/tests/mdc/std/std_example_funcs/std_increment.cpp
@@ -29,7 +29,7 @@
 
 #include "std_increment.hpp"
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__MINGW32__)
   #include <windows.h>
 #elif defined(__GNUC__)
   #include <unistd.h>
@@ -43,7 +43,7 @@ void Increment(int* value) {
   int temp = *value;
   temp += 1;
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__MINGW32__)
   Sleep(1);
 #elif defined(__GNUC__)
   usleep(1);


### PR DESCRIPTION
These changes fix problems in the code and CMakeLists.txt file to support compilation of MinGW Win32 targets on Linux. 