### PR TITLE
Fix compile for other MSVC versions

### DIFF
--- a/MDC/include/mdc/std/assert.h
+++ b/MDC/include/mdc/std/assert.h
@@ -46,10 +46,10 @@
 #define static_assert(expression, message)
 
 #endif /* defined(static_assert) \
-    || (!defined(__cplusplus) && __STDC_VERSION__ < 201112L) \
-    || (defined(__cplusplus) && __cplusplus < 201103L) \
-    || (!defined(__cplusplus) && _MSC_VER < 1600) \
-    || (defined(__cplusplus) && _MSC_VER < 1600) \
-    || (defined(__cplusplus) && defined(_MSVC_LANG) && _MSVC_LANG < 201103L) */
+    || (!defined(__cplusplus) && __STDC_VERSION__ < 201112L && !defined(_MSC_VER)) \
+    || (defined(__cplusplus) && __cplusplus < 201103L && !defined(_MSC_VER)) \
+    || (!defined(__cplusplus) && defined(_MSC_VER) && _MSC_VER < 1600) \
+    || (defined(__cplusplus) && defined(_MSC_VER) && _MSC_VER < 1600) \
+    || (defined(__cplusplus) && defined(_MSC_VER) && defined(_MSVC_LANG) && _MSVC_LANG < 201103L) */
 
 #endif /* MDC_C_STD_ASSERT_H_ */

--- a/MDC/include/mdc/std/assert.h
+++ b/MDC/include/mdc/std/assert.h
@@ -35,19 +35,21 @@
 
 #include <assert.h>
 
-#if !defined(static_assert) && \
-    (__STDC_VERSION__ < 201112L \
-        && __cpluplus < 201103L \
-        && _MSVC_LANG < 201103L) \
-    || _MSC_VER < 1600
+#if defined(static_assert) \
+    || (!defined(__cplusplus) && __STDC_VERSION__ < 201112L && !defined(_MSC_VER)) \
+    || (defined(__cplusplus) && __cplusplus < 201103L && !defined(_MSC_VER)) \
+    || (!defined(__cplusplus) && defined(_MSC_VER) && _MSC_VER < 1600) \
+    || (defined(__cplusplus) && defined(_MSC_VER) && _MSC_VER < 1600) \
+    || (defined(__cplusplus) && defined(_MSC_VER) && defined(_MSVC_LANG) && _MSVC_LANG < 201103L)
 
 /* Assert hackarounds fail to work with VC++ 6. */
 #define static_assert(expression, message)
 
-#endif /*  !defined(static_assert) && \
-    (__STDC_VERSION__ < 201112L \
-        && __cpluplus < 201103L \
-        && _MSVC_LANG < 201103L) \
-    || _MSC_VER < 1600 */
+#endif /* defined(static_assert) \
+    || (!defined(__cplusplus) && __STDC_VERSION__ < 201112L) \
+    || (defined(__cplusplus) && __cplusplus < 201103L) \
+    || (!defined(__cplusplus) && _MSC_VER < 1600) \
+    || (defined(__cplusplus) && _MSC_VER < 1600) \
+    || (defined(__cplusplus) && defined(_MSVC_LANG) && _MSVC_LANG < 201103L) */
 
 #endif /* MDC_C_STD_ASSERT_H_ */

--- a/MDC/include/mdc/std/stdbool.h
+++ b/MDC/include/mdc/std/stdbool.h
@@ -42,6 +42,7 @@ typedef unsigned char bool;
 #define true 1
 #define false 0
 
-#endif
+#endif /* __STDC_VERSION__ >= 199901L \
+    || _MSC_VER > 1700 */
 
 #endif /* MDC_C_STD_STDBOOL_H_ */

--- a/MDC/include/mdc/std/stdbool.h
+++ b/MDC/include/mdc/std/stdbool.h
@@ -31,7 +31,7 @@
 #define MDC_C_STD_STDBOOL_H_
 
 #if __STDC_VERSION__ >= 199901L \
-    || _MSC_VER >= 1600
+    || _MSC_VER > 1700
 
 #include <stdbool.h>
 

--- a/MDC/include/mdc/std/stdint.h
+++ b/MDC/include/mdc/std/stdint.h
@@ -32,7 +32,7 @@
 
 #if __cplusplus >= 201103L \
     ||  __STDC_VERSION__ >= 199901L \
-    || _MSC_VER > 1200
+    || _MSC_VER >= 1600
 
 #include <stdint.h>
 

--- a/MDC/include/mdc/std/stdint.h
+++ b/MDC/include/mdc/std/stdint.h
@@ -166,6 +166,8 @@ typedef uint32_t uintptr_t;
 
 #define UINTMAX_MAX UINT64_MAX
 
-#endif /* __STDC_VERSION__ >= 199901L */
+#endif /* __cplusplus >= 201103L \
+    ||  __STDC_VERSION__ >= 199901L \
+    || _MSC_VER >= 1600 */
 
 #endif /* MDC_C_STD_STDINT_H_ */

--- a/MDCcpp98/include/mdc/std/mutex.hpp
+++ b/MDCcpp98/include/mdc/std/mutex.hpp
@@ -236,6 +236,10 @@ class unique_lock {
  * Call once
  */
 
+class DLLEXPORT once_flag;
+
+DLLEXPORT void call_once(once_flag& flag, void (*func)(void));
+
 class DLLEXPORT once_flag {
  public:
   once_flag() throw();
@@ -251,8 +255,6 @@ class DLLEXPORT once_flag {
   once_flag(const once_flag&);
   once_flag& operator=(const once_flag&);
 };
-
-DLLEXPORT void call_once(once_flag& flag, void (*func)(void));
 
 } // namespace std
 


### PR DESCRIPTION
These changes fix compilation on all available Visual Studio project versions that can be generated by CMake. This also maintains compatibility with existing MinGW-cross compilation on Manjaro.