### PR TITLE
Clean up CMakeLists and add DLL link tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@
 # license, the licensors of this Program grant you additional permission
 # to convey the resulting work.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.11)
 
 project(MDC)
 

--- a/MDCc/CMakeLists.txt
+++ b/MDCc/CMakeLists.txt
@@ -23,20 +23,23 @@
 # license, the licensors of this Program grant you additional permission
 # to convey the resulting work.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.11)
 
+# Name of the project, also is the name of the file
 project(MDCc)
 
+# Define requirements for C
 set(CMAKE_C_STANDARD 90)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 
+# Remove MinGW compiled binary "lib" prefix
 if (MINGW)
     set(CMAKE_IMPORT_LIBRARY_PREFIX "")
     set(CMAKE_SHARED_LIBRARY_PREFIX "")
     set(CMAKE_STATIC_LIBRARY_PREFIX "")
 endif (MINGW)
 
-# Header and source files
+# List all of the source files here
 set(INCLUDE_HEADERS
     "dllexport_define.inc"
     "dllexport_define.inc"
@@ -66,19 +69,26 @@ set(SRC_C
 
 set(SRC_HEADERS)
 
-# Output static LIB
-add_library(libMDCc STATIC ${SRC_C} ${SRC_HEADERS} ${INCLUDE_HEADERS})
+set(SOURCE_FILES
+    "${INCLUDE_HEADERS}"
+    "${SRC_C}"
+    "${SRC_HEADERS}"
+)
 
-target_include_directories(libMDCc PUBLIC "include")
+# Output static LIB
+add_library(lib${PROJECT_NAME} STATIC ${SOURCE_FILES})
+
+target_include_directories(lib${PROJECT_NAME} PUBLIC "include")
 
 # Output DLL
-add_library(MDCc SHARED ${SRC_C} ${SRC_HEADERS} ${INCLUDE_HEADERS})
+add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
 
-target_compile_definitions(MDCc PRIVATE MDC_C_DLLEXPORT)
-target_compile_definitions(MDCc INTERFACE MDC_C_DLLIMPORT)
+target_compile_definitions(${PROJECT_NAME} PRIVATE MDC_C_DLLEXPORT)
+target_compile_definitions(${PROJECT_NAME} INTERFACE MDC_C_DLLIMPORT)
 
-target_include_directories(MDCc PUBLIC "include")
+target_include_directories(${PROJECT_NAME} PUBLIC "include")
 
-source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SRC_C} ${INCLUDE_HEADERS})
+# Project source listing
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SOURCE_FILES})
 
-install(TARGETS MDCc libMDCc)
+install(TARGETS ${PROJECT_NAME} lib${PROJECT_NAME})

--- a/MDCcpp98/CMakeLists.txt
+++ b/MDCcpp98/CMakeLists.txt
@@ -23,23 +23,27 @@
 # license, the licensors of this Program grant you additional permission
 # to convey the resulting work.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.11)
 
+# Name of the project, also is the name of the file
 project(MDCcpp98)
 
+# Define requirements for C
 set(CMAKE_C_STANDARD 90)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 
+# Define requirements for C++
 set(CMAKE_CXX_STANDARD 98)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Remove MinGW compiled binary "lib" prefix
 if (MINGW)
     set(CMAKE_IMPORT_LIBRARY_PREFIX "")
     set(CMAKE_SHARED_LIBRARY_PREFIX "")
     set(CMAKE_STATIC_LIBRARY_PREFIX "")
 endif (MINGW)
 
-# Header and source files
+# List all of the source files here
 set(INCLUDE_HEADERS
     "dllexport_define.inc"
     "dllexport_define.inc"
@@ -65,25 +69,32 @@ set(SRC_C
 
 set(SRC_HEADERS)
 
+set(SOURCE_FILES
+    "${INCLUDE_HEADERS}"
+    "${SRC_C}"
+    "${SRC_HEADERS}"
+)
+
 # Output static LIB
-add_library(libMDCcpp98 STATIC ${SRC_C} ${SRC_HEADERS} ${INCLUDE_HEADERS})
+add_library(lib${PROJECT_NAME} STATIC ${SOURCE_FILES})
 
-target_include_directories(libMDCcpp98 PUBLIC "include")
+target_include_directories(lib${PROJECT_NAME} PUBLIC "include")
 
-target_link_libraries(libMDCcpp98 libMDCc)
-add_dependencies(libMDCcpp98 libMDCc)
+target_link_libraries(lib${PROJECT_NAME} libMDCc)
+add_dependencies(lib${PROJECT_NAME} libMDCc)
 
 # Output DLL
-add_library(MDCcpp98 SHARED ${SRC_C} ${SRC_HEADERS} ${INCLUDE_HEADERS})
+add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
 
-target_compile_definitions(MDCcpp98 PRIVATE MDC_CPP98_DLLEXPORT)
-target_compile_definitions(MDCcpp98 INTERFACE MDC_CPP98_DLLEXPORT)
+target_compile_definitions(${PROJECT_NAME} PRIVATE MDC_CPP98_DLLEXPORT)
+target_compile_definitions(${PROJECT_NAME} INTERFACE MDC_CPP98_DLLEXPORT)
 
-target_include_directories(MDCcpp98 PUBLIC "include")
+target_include_directories(${PROJECT_NAME} PUBLIC "include")
 
-target_link_libraries(MDCcpp98 MDCc)
-add_dependencies(MDCcpp98 MDCc)
+target_link_libraries(${PROJECT_NAME} MDCc)
+add_dependencies(${PROJECT_NAME} MDCc)
 
-source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SRC_C} ${INCLUDE_HEADERS})
+# Project source listing
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SOURCE_FILES})
 
-install(TARGETS MDCcpp98 libMDCcpp98)
+install(TARGETS ${PROJECT_NAME} lib${PROJECT_NAME})

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -23,14 +23,16 @@
 # license, the licensors of this Program grant you additional permission
 # to convey the resulting work.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.11)
 
+# Name of the project, also is the name of the file
 project(Tests)
 
+# Define requirements for C
 set(CMAKE_C_STANDARD 90)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 
-# Header and source files
+# Remove MinGW compiled binary "lib" prefix
 set(SRC_C
     "tests/mdc/error/exit_on_error_tests.c"
     "tests/mdc/std/assert_tests.c"
@@ -62,12 +64,24 @@ set(SRC_HEADER
     "tests/mdc/wchar_t_tests.h"
 )
 
+set(SOURCE_FILES
+    "${SRC_C}"
+    "${SRC_HEADERS}"
+)
+
 # Output test EXE
-add_executable(Tests ${SRC_C} ${SRC_HEADER})
+add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 
-target_link_libraries(Tests MDCc)
-add_dependencies(Tests MDCc)
+target_link_libraries(${PROJECT_NAME} MDCc)
+add_dependencies(${PROJECT_NAME} MDCc)
 
-source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SRC_C} ${SRC_HEADER})
+# Output test EXE (static)
+add_executable(${PROJECT_NAME}.static ${SOURCE_FILES})
 
-install(TARGETS Tests)
+target_link_libraries(${PROJECT_NAME}.static libMDCc)
+add_dependencies(${PROJECT_NAME}.static libMDCc)
+
+# Project source listing
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SOURCE_FILES})
+
+install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}.static)

--- a/TestsCpp98/CMakeLists.txt
+++ b/TestsCpp98/CMakeLists.txt
@@ -23,17 +23,20 @@
 # license, the licensors of this Program grant you additional permission
 # to convey the resulting work.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.11)
 
+# Name of the project, also is the name of the file
 project(TestsCpp98)
 
+# Define requirements for C
 set(CMAKE_C_STANDARD 90)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 
+# Define requirements for C++
 set(CMAKE_CXX_STANDARD 98)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Header and source files
+# Remove MinGW compiled binary "lib" prefix
 set(SRC_C
     "tests/mdc/error/exit_on_error_tests.cpp"
     "tests/mdc/std/std_example_funcs/std_increment.cpp"
@@ -65,12 +68,24 @@ set(SRC_HEADER
     "tests/mdc/wchar_t_tests.hpp"
 )
 
+set(SOURCE_FILES
+    "${SRC_C}"
+    "${SRC_HEADERS}"
+)
+
 # Output test EXE
-add_executable(TestsCpp98 ${SRC_C} ${SRC_HEADER})
+add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 
-target_link_libraries(TestsCpp98 MDCc MDCcpp98)
-add_dependencies(TestsCpp98 MDCc MDCcpp98)
+target_link_libraries(${PROJECT_NAME} MDCc MDCcpp98)
+add_dependencies(${PROJECT_NAME} MDCc MDCcpp98)
 
-source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SRC_C} ${SRC_HEADER})
+# Output test EXE (static)
+add_executable(${PROJECT_NAME}.static ${SOURCE_FILES})
 
-install(TARGETS TestsCpp98)
+target_link_libraries(${PROJECT_NAME}.static libMDCc libMDCcpp98)
+add_dependencies(${PROJECT_NAME}.static libMDCc libMDCcpp98)
+
+# Project source listing
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SOURCE_FILES})
+
+install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}.static)


### PR DESCRIPTION
These changes clean up the CMakeLists.txt files, while also adding documenting comments. DLL link tests have been added to also  test the DLL versions of the libraries.